### PR TITLE
Updating New SUM20SP16 Patch 8 to BOM

### DIFF
--- a/SAP/SUM20SP16_latest/SUM20SP16_latest.yaml
+++ b/SAP/SUM20SP16_latest/SUM20SP16_latest.yaml
@@ -1,15 +1,15 @@
 ---
 name:    'SUM20SP16'
 target:  'SUM20SP16'
-version: 007
+version: 008
 
 materials:
 
   media:
     # SUM
-    - name:         "Patch 7 for SOFTWARE UPDATE MANAGER 2.0 SP16 (Linux on x86_64)"
-      archive:      SUM20SP16_7-80002456.SAR
-      checksum:     3c841a317540d82442da9c41bae30ea442aa983fcfbd800cde70c720b22f8571
+    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP16 (Linux on x86_64)"
+      archive:      SUM20SP16_8-80002456.SAR
+      checksum:     e32297d71df69f0b217de8c0429094984b47a5dfd8d0b808becc7c91ea48da1b
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000551952023
+      url:          https://softwaredownloads.sap.com/file/0020000000619342023
 

--- a/SAP/SUM20SP16_win_latest/SUM20SP16_win_latest.yaml
+++ b/SAP/SUM20SP16_win_latest/SUM20SP16_win_latest.yaml
@@ -1,14 +1,14 @@
 ---
 name:    'SUM20SP16'
 target:  'SUM20SP16'
-version: 007
+version: 008
 
 materials:
 
   media:
 
-    - name:         "Patch 7 for SOFTWARE UPDATE MANAGER 2.0 SP16 (Windows)"
-      archive:      SUM20SP16_7-80002458.SAR
-      checksum:     5a34f7839a5df2d4e74e3be3ea78d1d0f33b0a91a88422e238cc16fac240a54a
+    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP16 (Windows)"
+      archive:      SUM20SP16_8-80002458.SAR
+      checksum:     ac271727772494376912f174e783f28c6afabc662aa828d49c7e4ed0a27a92d9
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000551982023
+      url:          https://softwaredownloads.sap.com/file/0020000000619352023


### PR DESCRIPTION
SUM20SP16 Patch 7 is no longer available now at SAP Marketplace and SAP has released SUM20SP16 Patch 8. Need to update the  same on BOMs