### PR TITLE
SP12 Patch6 for UMML4HANA 1 is not available

### DIFF
--- a/SAP/S41909SPS03_v0011ms/S41909SPS03_v0011ms.yaml
+++ b/SAP/S41909SPS03_v0011ms/S41909SPS03_v0011ms.yaml
@@ -229,11 +229,11 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0020000000410162020
 
-    - name:         "SP12 Patch6 for UMML4HANA 1"
-      archive:      HANAUMML12_6-70001054.ZIP
-      checksum:     f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
+    - name:         "SP12 Patch7 for UMML4HANA 1"
+      archive:      HANAUMML12_7-70001054.ZIP
+      checksum:     c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000356792022
+      url:          https://softwaredownloads.sap.com/file/0020000000665292023
 
     # SPAM
     - name:         "SPAM/SAINT Update - Version 754/0077"

--- a/SAP/S41909SPS03_v0012ms/S41909SPS03_v0012ms.yaml
+++ b/SAP/S41909SPS03_v0012ms/S41909SPS03_v0012ms.yaml
@@ -241,11 +241,11 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0020000000410162020
 
-    - name:         "SP12 Patch6 for UMML4HANA 1"
-      archive:      HANAUMML12_6-70001054.ZIP
-      checksum:     f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
+    - name:         "SP12 Patch7 for UMML4HANA 1"
+      archive:      HANAUMML12_7-70001054.ZIP
+      checksum:     c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000356792022
+      url:          https://softwaredownloads.sap.com/file/0020000000665292023
 
     # SPAM
     - name:         "SPAM/SAINT Update - Version 754/0077"

--- a/SAP/S42020SPS04_v0001ms/S42020SPS04_v0001ms.yaml
+++ b/SAP/S42020SPS04_v0001ms/S42020SPS04_v0001ms.yaml
@@ -31,9 +31,9 @@ materials:
 
     # kernel components
 
-    - name: "SP12 Patch6 for UMML4HANA 1"
-      archive: HANAUMML12_6-70001054.ZIP
-      url: https://softwaredownloads.sap.com/file/0020000000356792022
+    - name: "SP12 Patch7 for UMML4HANA 1"
+      archive: HANAUMML12_7-70001054.ZIP
+      url: https://softwaredownloads.sap.com/file/0020000000665292023
       path: download_basket
 
     - name: "SAP HANA CLIENT Version 2.13"

--- a/SAP/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
+++ b/SAP/S42021SPS00_v0001ms/S42021SPS00_v0001ms.yaml
@@ -28,9 +28,9 @@ materials:
 
     # kernel components
 
-    - name:                            "SP12 Patch6 for UMML4HANA 1"
-      archive:                         HANAUMML12_6-70001054.ZIP
-      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:                            "SP12 Patch7 for UMML4HANA 1"
+      archive:                         HANAUMML12_7-70001054.ZIP
+      url:                             https://softwaredownloads.sap.com/file/0020000000665292023
       path:                            download_basket
 
     - name:                            "SAP HANA CLIENT Version 2.12"

--- a/SAP/S42022SPS00_v0001ms/S42022SPS00_v0001ms.yaml
+++ b/SAP/S42022SPS00_v0001ms/S42022SPS00_v0001ms.yaml
@@ -73,10 +73,10 @@ materials:
       path:                            download_basket
 
     # MISC
-    - name:                            "SP12 Patch6 for UMML4HANA 1"
-      archive:                         HANAUMML12_6-70001054.ZIP
-      checksum:                        f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
-      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:                            "SP12 Patch7 for UMML4HANA 1"
+      archive:                         HANAUMML12_7-70001054.ZIP
+      checksum:                        c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      url:                             https://softwaredownloads.sap.com/file/0020000000665292023
       path:                            download_basket
 
     - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"

--- a/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
+++ b/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
@@ -71,10 +71,10 @@ materials:
       path:         download_basket
 
     #MISC
-    - name:         "SP12 Patch6 for UMML4HANA 1"
-      archive:      HANAUMML12_6-70001054.ZIP
-      checksum:     f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
-      url:          https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:         "SP12 Patch7 for UMML4HANA 1"
+      archive:      HANAUMML12_7-70001054.ZIP
+      checksum:     c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      url:          https://softwaredownloads.sap.com/file/0020000000665292023
       path:         download_basket
 
     - name:         "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"

--- a/SAP/S4HANA_2021_FP01_v0002ms/S4HANA_2021_FP01_v0002ms.yaml
+++ b/SAP/S4HANA_2021_FP01_v0002ms/S4HANA_2021_FP01_v0002ms.yaml
@@ -84,10 +84,10 @@ materials:
       path:         download_basket
 
     #MISC
-    - name:         "SP12 Patch6 for UMML4HANA 1"
-      archive:      HANAUMML12_6-70001054.ZIP
-      checksum:     f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
-      url:          https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:         "SP12 Patch7 for UMML4HANA 1"
+      archive:      HANAUMML12_7-70001054.ZIP
+      checksum:     c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      url:          https://softwaredownloads.sap.com/file/0020000000665292023
       path:         download_basket
 
     - name:         "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"

--- a/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -74,10 +74,10 @@ materials:
       path:                            download_basket
 
     # MISC
-    - name:                            "SP12 Patch6 for UMML4HANA 1"
-      archive:                         HANAUMML12_6-70001054.ZIP
-      checksum:                        f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
-      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:                            "SP12 Patch7 for UMML4HANA 1"
+      archive:                         HANAUMML12_7-70001054.ZIP
+      checksum:                        c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      url:                             https://softwaredownloads.sap.com/file/0020000000665292023
       path:                            download_basket
 
     - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"

--- a/SAP/S4HANA_2021_ISS_v0002ms/S4HANA_2021_ISS_v0002ms.yaml
+++ b/SAP/S4HANA_2021_ISS_v0002ms/S4HANA_2021_ISS_v0002ms.yaml
@@ -86,10 +86,10 @@ materials:
       path:                            download_basket
 
     # MISC
-    - name:                            "SP12 Patch6 for UMML4HANA 1"
-      archive:                         HANAUMML12_6-70001054.ZIP
-      checksum:                        f103c2434f0762bb6210e8fcf26b99490bb26d13be6d6d1981a3e4bbf4f2c8be
-      url:                             https://softwaredownloads.sap.com/file/0020000000356792022
+    - name:                            "SP12 Patch7 for UMML4HANA 1"
+      archive:                         HANAUMML12_7-70001054.ZIP
+      checksum:                        c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      url:                             https://softwaredownloads.sap.com/file/0020000000665292023
       path:                            download_basket
 
     - name:                            "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond"


### PR DESCRIPTION
SP12 Patch6 for UMML4HANA 1 is not available. Replaced the SP12 Patch7 for UMMLHANA 1
