### PR TITLE
Update missing HANA BoM Name in dependencies

### DIFF
--- a/SAP/NW750SPS20_v0004ms/NW750SPS20_v0004ms.yaml
+++ b/SAP/NW750SPS20_v0004ms/NW750SPS20_v0004ms.yaml
@@ -21,7 +21,7 @@ product_ids:
 
 materials:
   dependencies:
-    - name:                            HANA_2_00_067_v0003ms
+    - name:                            HANA_2_00_067_v0004ms
     - name:                            SWPM10SP37_latest
     - name:                            SUM20SP17_latest
 

--- a/SAP/NW750SPS25_v0001ms/NW750SPS25_v0001ms.yaml
+++ b/SAP/NW750SPS25_v0001ms/NW750SPS25_v0001ms.yaml
@@ -22,7 +22,7 @@ product_ids:
 
 materials:
   dependencies:
-    - name:                            HANA_2_00_067_v0003ms
+    - name:                            HANA_2_00_067_v0004ms
     - name:                            SWPM10SP36_latest
     - name:                            SUM20SP15_latest
 

--- a/SAP/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
+++ b/SAP/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
@@ -25,7 +25,7 @@
 
     materials:
       dependencies:
-        - name:     HANA_2_00_067_v0003ms
+        - name:     HANA_2_00_067_v0004ms
         - name:     SWPM20SP15_latest
         - name:     SUM20SP17_latest
 

--- a/SAP/S42020SPS03_v0004ms/S42020SPS03_v0004ms.yaml
+++ b/SAP/S42020SPS03_v0004ms/S42020SPS03_v0004ms.yaml
@@ -25,7 +25,7 @@
 
     materials:
       dependencies:
-        - name:     HANA_2_00_067_v0003ms
+        - name:     HANA_2_00_067_v0004ms
 
       media:
 

--- a/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
+++ b/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
@@ -23,7 +23,7 @@ product_ids:
 
 materials:
   dependencies:
-    - name:         "HANA_2_00_067_v0003ms"
+    - name:         "HANA_2_00_067_v0004ms"
     - name:         "SWPM20SP11_latest"
     - name:         "SUM20SP17_latest"
   media:

--- a/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -26,7 +26,7 @@ product_ids:
 
 materials:
   dependencies:
-    - name:                            "HANA_2_00_067_v0003ms"
+    - name:                            "HANA_2_00_067_v0004ms"
     - name:                            "SWPM20SP15_latest"
     - name:                            "SUM20SP17_latest"
   media:


### PR DESCRIPTION
New HANA BoM version was missed inside the main SAP Boms in dependencies