### PR TITLE
Upd BoMs with GBX01HR5605, ST-PI740 and UIHR002100

### DIFF
--- a/SAP/ERP6_EHP8_LNX_DB2UDB_11_5_v0001ms/ERP6_EHP8_LNX_DB2UDB_11_5_v0001ms.yaml
+++ b/SAP/ERP6_EHP8_LNX_DB2UDB_11_5_v0001ms/ERP6_EHP8_LNX_DB2UDB_11_5_v0001ms.yaml
@@ -4181,7 +4181,7 @@ materials:
       url: https://softwaredownloads.sap.com/file/0010000000067452016
       download: false
 
-    - name: "Attribute Change Package 45 for ST-PI 740"
+    - name: "Attribute Change Package 56 for ST-PI 740"
       archive: ST-PI740.SAR
       url: https://softwaredownloads.sap.com/file/0010000000297212015
       download: false

--- a/SAP/ERP6_EHP8_LNX_HANA_17_v0001ms/ERP6_EHP8_LNX_HANA_17_v0001ms.yaml
+++ b/SAP/ERP6_EHP8_LNX_HANA_17_v0001ms/ERP6_EHP8_LNX_HANA_17_v0001ms.yaml
@@ -4889,7 +4889,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000067452016
       download:     false
 
-    - name:         "Attribute Change Package 54 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive: ST-PI740.SAR
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
       download:     false

--- a/SAP/ERP6_EHP8_WIN_MSS2016_v0001ms/ERP6_EHP8_WIN_MSS2016_v0001ms.yaml
+++ b/SAP/ERP6_EHP8_WIN_MSS2016_v0001ms/ERP6_EHP8_WIN_MSS2016_v0001ms.yaml
@@ -3112,7 +3112,7 @@ materials:
       url: https://softwaredownloads.sap.com/file/0010000000067452016
       download: false
 
-    - name: "Attribute Change Package 45 for ST-PI 740"
+    - name: "Attribute Change Package 56 for ST-PI 740"
       archive: ST-PI740.SAR
       url: https://softwaredownloads.sap.com/file/0010000000297212015
       download: false

--- a/SAP/ERP6_EHP8_WIN_MSS2019_v0001ms/ERP6_EHP8_WIN_MSS2019_v0001ms.yaml
+++ b/SAP/ERP6_EHP8_WIN_MSS2019_v0001ms/ERP6_EHP8_WIN_MSS2019_v0001ms.yaml
@@ -3128,7 +3128,7 @@ materials:
       url:                      https://softwaredownloads.sap.com/file/0010000000067452016
       download: false
 
-    - name:                     "Attribute Change Package 45 for ST-PI 740"
+    - name:                     "Attribute Change Package 56 for ST-PI 740"
       archive:                  ST-PI740.SAR
       url:                      https://softwaredownloads.sap.com/file/0010000000297212015
       download: false

--- a/SAP/NW750SPS20_DB2_v0001ms/NW750SPS20_DB2_v0001ms.yaml
+++ b/SAP/NW750SPS20_DB2_v0001ms/NW750SPS20_DB2_v0001ms.yaml
@@ -446,9 +446,9 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000031692020
       download:     false
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
-      checksum:     8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328
+      checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
       download:     false
 

--- a/SAP/NW750SPS20_SYBASE_v0001ms/NW750SPS20_SYBASE_v0001ms.yaml
+++ b/SAP/NW750SPS20_SYBASE_v0001ms/NW750SPS20_SYBASE_v0001ms.yaml
@@ -449,9 +449,9 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000031692020
       download:     false
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
-      checksum:     8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328
+      checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
       download:     false
 

--- a/SAP/NW750SPS20_v0004ms/NW750SPS20_v0004ms.yaml
+++ b/SAP/NW750SPS20_v0004ms/NW750SPS20_v0004ms.yaml
@@ -711,9 +711,9 @@ materials:
       download:                        false
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
 
-    - name:                            "Attribute Change Package 34 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
-      checksum:                        02132b43b349c45e8fc6731ceb8a78ef406477a942637bb53b8228d9e11ad6a7
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       download:                        false
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
 

--- a/SAP/NW750SPS25_v0001ms/NW750SPS25_v0001ms.yaml
+++ b/SAP/NW750SPS25_v0001ms/NW750SPS25_v0001ms.yaml
@@ -750,7 +750,7 @@ materials:
       url: https://softwaredownloads.sap.com/file/0010000000031692020
       download: false
 
-    - name: "Attribute Change Package 54 for ST-PI 740"
+    - name: "Attribute Change Package 56 for ST-PI 740"
       archive: ST-PI740.SAR
       url: https://softwaredownloads.sap.com/file/0010000000297212015
       download: false

--- a/SAP/NW750_HANA_v0004ms/NW750_HANA_v0004ms.yaml
+++ b/SAP/NW750_HANA_v0004ms/NW750_HANA_v0004ms.yaml
@@ -718,9 +718,9 @@ materials:
       download:                        false
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
 
-    - name:                            "Attribute Change Package 34 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
-      checksum:                        02132b43b349c45e8fc6731ceb8a78ef406477a942637bb53b8228d9e11ad6a7
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       download:                        false
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
 

--- a/SAP/NW750_MSSQL_v0001ms/NW750_MSSQL_v0001ms.yaml
+++ b/SAP/NW750_MSSQL_v0001ms/NW750_MSSQL_v0001ms.yaml
@@ -737,7 +737,7 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false

--- a/SAP/NW752SPS09_v0001ms/NW752SPS09_v0001ms.yaml
+++ b/SAP/NW752SPS09_v0001ms/NW752SPS09_v0001ms.yaml
@@ -453,9 +453,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
-      checksum:                        8406c3d057afd459406b3d2fa500a1050eb8ac3c81be165d19af6e5834725328
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false
 

--- a/SAP/NW752_MSSQL_v0001ms/NW752_MSSQL_v0001ms.yaml
+++ b/SAP/NW752_MSSQL_v0001ms/NW752_MSSQL_v0001ms.yaml
@@ -756,7 +756,7 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false

--- a/SAP/NW_MSSQL_v0001ms/NW_MSSQL_v0001ms.yaml
+++ b/SAP/NW_MSSQL_v0001ms/NW_MSSQL_v0001ms.yaml
@@ -754,7 +754,7 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000031692020
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false

--- a/SAP/S41909SPS03_v0011ms/S41909SPS03_v0011ms.yaml
+++ b/SAP/S41909SPS03_v0011ms/S41909SPS03_v0011ms.yaml
@@ -249,9 +249,9 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000059642016
 
-    - name:         "Attribute Change Package 26 for GBX01HR5 605"
+    - name:         "Attribute Change Package 28 for GBX01HR5 605"
       archive:      GBX01HR5605.SAR
-      checksum:     19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+      checksum:     9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000033172015
 
@@ -957,9 +957,9 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000001964502018
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
-      checksum:     2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+      checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
 

--- a/SAP/S41909SPS03_v0012ms/S41909SPS03_v0012ms.yaml
+++ b/SAP/S41909SPS03_v0012ms/S41909SPS03_v0012ms.yaml
@@ -261,9 +261,9 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000059642016
 
-    - name:         "Attribute Change Package 26 for GBX01HR5 605"
+    - name:         "Attribute Change Package 28 for GBX01HR5 605"
       archive:      GBX01HR5605.SAR
-      checksum:     19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+      checksum:     9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000033172015
 
@@ -969,9 +969,9 @@ materials:
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000001964502018
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
-      checksum:     2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+      checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       download:     false
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
 

--- a/SAP/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
+++ b/SAP/S42020SPS03_v0003ms/S42020SPS03_v0003ms.yaml
@@ -237,9 +237,9 @@
           url: https://softwaredownloads.sap.com/file/0010000000059642016
           download: false
 
-        - name: "Attribute Change Package 26 for GBX01HR5 605"
+        - name: "Attribute Change Package 28 for GBX01HR5 605"
           archive: GBX01HR5605.SAR
-          checksum: 19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+          checksum: 9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
           url: https://softwaredownloads.sap.com/file/0010000000033172015
           download: false
 
@@ -993,9 +993,9 @@
           url: https://softwaredownloads.sap.com/file/0010000000060132013
           download: false
 
-        - name: "Attribute Change Package 45 for ST-PI 740"
+        - name: "Attribute Change Package 56 for ST-PI 740"
           archive: ST-PI740.SAR
-          checksum: 2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+          checksum: 564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
           url: https://softwaredownloads.sap.com/file/0010000000297212015
           download: false
 

--- a/SAP/S42020SPS03_v0004ms/S42020SPS03_v0004ms.yaml
+++ b/SAP/S42020SPS03_v0004ms/S42020SPS03_v0004ms.yaml
@@ -249,9 +249,9 @@
           url:          https://softwaredownloads.sap.com/file/0010000000059642016
           download:     false
 
-        - name:         "Attribute Change Package 26 for GBX01HR5 605"
+        - name:         "Attribute Change Package 28 for GBX01HR5 605"
           archive:      GBX01HR5605.SAR
-          checksum:     19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+          checksum:     9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
           url:          https://softwaredownloads.sap.com/file/0010000000033172015
           download:     false
 
@@ -1005,9 +1005,9 @@
           url:          https://softwaredownloads.sap.com/file/0010000000060132013
           download:     false
 
-        - name:         "Attribute Change Package 45 for ST-PI 740"
+        - name:         "Attribute Change Package 56 for ST-PI 740"
           archive:      ST-PI740.SAR
-          checksum:     2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+          checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
           url:          https://softwaredownloads.sap.com/file/0010000000297212015
           download:     false
 

--- a/SAP/S42020SPS04_v0001ms/S42020SPS04_v0001ms.yaml
+++ b/SAP/S42020SPS04_v0001ms/S42020SPS04_v0001ms.yaml
@@ -210,7 +210,7 @@ materials:
       url: https://softwaredownloads.sap.com/file/0010000000059642016
       download: false
 
-    - name: "Attribute Change Package 26 for GBX01HR5 605"
+    - name: "Attribute Change Package 28 for GBX01HR5 605"
       archive: GBX01HR5605.SAR
       url: https://softwaredownloads.sap.com/file/0010000000033172015
       download: false
@@ -1040,7 +1040,7 @@ materials:
       url: https://softwaredownloads.sap.com/file/0010000000060132013
       download: false
 
-    - name: "Attribute Change Package 45 for ST-PI 740"
+    - name: "Attribute Change Package 56 for ST-PI 740"
       archive: ST-PI740.SAR
       url: https://softwaredownloads.sap.com/file/0010000000297212015
       download: false

--- a/SAP/S42022SPS00_v0001ms/S42022SPS00_v0001ms.yaml
+++ b/SAP/S42022SPS00_v0001ms/S42022SPS00_v0001ms.yaml
@@ -300,21 +300,21 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000828662023
       download:                        false
 
-    - name:                            "Attribute Change Package 17 for EA-HR 608"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740
-      checksum:                        2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false
 
-    - name:                            "Attribute Change Package 19 for GBX01HR 600"
+    - name:                            "Attribute Change Package 28 for GBX01HR 600"
       archive:                         GBX01HR5605
-      checksum:                        19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+      checksum:                        9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
       url:                             https://softwaredownloads.sap.com/file/0010000000033172015
       download:                        false
  
-    - name:                            "UIHR002 100: SP 0001"
+    - name:                            "Attribute Change Package 33 for UIHR002 100"
       archive:                         UIHR002100
-      checksum:                        af4dc627a4e9896a29506cff4b0804085299f97ce8a414ebf930d5bff0aad2b6
+      checksum:                        cf8a38e5b94d27ebc35f1b79ecd7d3363c350518e4d9a7ef0de830c8fc3ba350
       url:                             https://softwaredownloads.sap.com/file/0010000020208092017
       download:                        false
 

--- a/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
+++ b/SAP/S4HANA_2021_FP01_v0001ms/S4HANA_2021_FP01_v0001ms.yaml
@@ -281,7 +281,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000059642016
       download:     false
 
-    - name:         "Attribute Change Package 22 for GBX01HR5 605"
+    - name:         "Attribute Change Package 28 for GBX01HR5 605"
       archive:      GBX01HR5605.SAR
       url:          https://softwaredownloads.sap.com/file/0010000000033172015
       download:     false
@@ -696,7 +696,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000249512014
       download:     false
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
       download:     false
@@ -711,7 +711,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000001617952021
       download:     false
 
-    - name:         "Attribute Change Package 30 for UIHR002 100"
+    - name:         "Attribute Change Package 33 for UIHR002 100"
       archive:      UIHR002100.SAR
       url:          https://softwaredownloads.sap.com/file/0010000020208092017
       download:     false

--- a/SAP/S4HANA_2021_FP01_v0002ms/S4HANA_2021_FP01_v0002ms.yaml
+++ b/SAP/S4HANA_2021_FP01_v0002ms/S4HANA_2021_FP01_v0002ms.yaml
@@ -294,7 +294,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000059642016
       download:     false
 
-    - name:         "Attribute Change Package 22 for GBX01HR5 605"
+    - name:         "Attribute Change Package 28 for GBX01HR5 605"
       archive:      GBX01HR5605.SAR
       url:          https://softwaredownloads.sap.com/file/0010000000033172015
       download:     false
@@ -709,7 +709,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000000249512014
       download:     false
 
-    - name:         "Attribute Change Package 45 for ST-PI 740"
+    - name:         "Attribute Change Package 56 for ST-PI 740"
       archive:      ST-PI740.SAR
       url:          https://softwaredownloads.sap.com/file/0010000000297212015
       download:     false
@@ -724,7 +724,7 @@ materials:
       url:          https://softwaredownloads.sap.com/file/0010000001617952021
       download:     false
 
-    - name:         "Attribute Change Package 30 for UIHR002 100"
+    - name:         "Attribute Change Package 33 for UIHR002 100"
       archive:      UIHR002100.SAR
       url:          https://softwaredownloads.sap.com/file/0010000020208092017
       download:     false

--- a/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
+++ b/SAP/S4HANA_2021_ISS_v0001ms/S4HANA_2021_ISS_v0001ms.yaml
@@ -283,9 +283,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000059642016
       download:                        false
 
-    - name:                            "Attribute Change Package 22 for GBX01HR5 605"
+    - name:                            "Attribute Change Package 28 for GBX01HR5 605"
       archive:                         GBX01HR5605.SAR
-      checksum:                        19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+      checksum:                        9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
       url:                             https://softwaredownloads.sap.com/file/0010000000033172015
       download:                        false
 
@@ -535,9 +535,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000249512014
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
-      checksum:                        2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false
 
@@ -553,9 +553,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000001617952021
       download:                        false
 
-    - name:                            "Attribute Change Package 30 for UIHR002 100"
+    - name:                            "Attribute Change Package 33 for UIHR002 100"
       archive:                         UIHR002100.SAR
-      checksum:                        af4dc627a4e9896a29506cff4b0804085299f97ce8a414ebf930d5bff0aad2b6
+      checksum:                        cf8a38e5b94d27ebc35f1b79ecd7d3363c350518e4d9a7ef0de830c8fc3ba350
       url:                             https://softwaredownloads.sap.com/file/0010000020208092017
       download:                        false
 

--- a/SAP/S4HANA_2021_ISS_v0002ms/S4HANA_2021_ISS_v0002ms.yaml
+++ b/SAP/S4HANA_2021_ISS_v0002ms/S4HANA_2021_ISS_v0002ms.yaml
@@ -295,9 +295,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000059642016
       download:                        false
 
-    - name:                            "Attribute Change Package 22 for GBX01HR5 605"
+    - name:                            "Attribute Change Package 28 for GBX01HR5 605"
       archive:                         GBX01HR5605.SAR
-      checksum:                        19d06ed87c3fc1b9390fafa94d9a2d25ddabd3c0e61777a693e6155f113fa167
+      checksum:                        9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
       url:                             https://softwaredownloads.sap.com/file/0010000000033172015
       download:                        false
 
@@ -547,9 +547,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000000249512014
       download:                        false
 
-    - name:                            "Attribute Change Package 45 for ST-PI 740"
+    - name:                            "Attribute Change Package 56 for ST-PI 740"
       archive:                         ST-PI740.SAR
-      checksum:                        2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8
+      checksum:                        564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
       url:                             https://softwaredownloads.sap.com/file/0010000000297212015
       download:                        false
 
@@ -565,9 +565,9 @@ materials:
       url:                             https://softwaredownloads.sap.com/file/0010000001617952021
       download:                        false
 
-    - name:                            "Attribute Change Package 30 for UIHR002 100"
+    - name:                            "Attribute Change Package 33 for UIHR002 100"
       archive:                         UIHR002100.SAR
-      checksum:                        af4dc627a4e9896a29506cff4b0804085299f97ce8a414ebf930d5bff0aad2b6
+      checksum:                        cf8a38e5b94d27ebc35f1b79ecd7d3363c350518e4d9a7ef0de830c8fc3ba350
       url:                             https://softwaredownloads.sap.com/file/0010000020208092017
       download:                        false
 

--- a/SAP/TEST_BOM/TEST_BOM.yaml
+++ b/SAP/TEST_BOM/TEST_BOM.yaml
@@ -1129,9 +1129,9 @@ materials:
       checksum:                       e5e0239d48ad104c78316a5f3367daf3e51d07a881182904db585195f222d42d 
       url:                            https://softwaredownloads.sap.com/file/0010000000048162010
       download:                       true
-    - name:                           "Attribute Change Package 54 for ST-PI 740"
+    - name:                           "Attribute Change Package 56 for ST-PI 740"
       archive:                        ST-PI740.SAR
-      checksum:                       2b87eb02fa26dd8279a37eaa4c1ee64adab8bccbaca668f1e32ff421bdfbf9c8 
+      checksum:                       564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c 
       url:                            https://softwaredownloads.sap.com/file/0010000000297212015
       download:                       true
     - name:                           "Attribute Change Package 06 for SAP_AP 700"


### PR DESCRIPTION
SAP has updated the files for GBX01HR5605, ST-PI740 and UIHR002100 bits, this results in the change in the checksum of the files.
Updated the checksum of the files for the BoM