### PR TITLE
Upd links for SUM20SP17 Patch 6

### DIFF
--- a/SAP/SUM20SP17_latest/SUM20SP17_latest.yaml
+++ b/SAP/SUM20SP17_latest/SUM20SP17_latest.yaml
@@ -1,15 +1,15 @@
 ---
 name:    'SUM20SP17'
 target:  'SUM20SP17'
-version: 005
+version: 006
 
 materials:
 
   media:
     # SUM
-    - name:         "Patch 5 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
-      archive:      SUM20SP17_5-80002456.SAR
-      checksum:     de769c993dccd1ac1e1653f3bd718c403e68914ed2631c248da129c0955e5c26
+    - name:         "Patch 6 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
+      archive:      SUM20SP17_6-80002456.SAR
+      checksum:     4b6628b53bf34901746685325843836a5234a8d43e6914ff58750f018f813f22
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000946192023
+      url:          https://softwaredownloads.sap.com/file/0020000001010152023
 

--- a/SAP/SUM20SP17_win_latest/SUM20SP17_win_latest.yaml
+++ b/SAP/SUM20SP17_win_latest/SUM20SP17_win_latest.yaml
@@ -1,14 +1,14 @@
 ---
 name:    'SUM20SP17'
 target:  'SUM20SP17'
-version: 005
+version: 006
 
 materials:
 
   media:
 
-    - name:         "Patch 5 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
-      archive:      SUM20SP17_5-80002458.SAR
-      checksum:     023ce9daf7ce31b34ff5ec814a729360241adcb099d926f124603c142a73e8d7
+    - name:         "Patch 6 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
+      archive:      SUM20SP17_6-80002458.SAR
+      checksum:     42c9627da41328ed0f5c2ad26b0a3e8841d6bcc33509c4a3f3431de7a0868b04
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000000946252023
+      url:          https://softwaredownloads.sap.com/file/0020000001010182023

--- a/SAP/archives/SUM20SP17_v0005ms/SUM20SP17_v0005ms.yaml
+++ b/SAP/archives/SUM20SP17_v0005ms/SUM20SP17_v0005ms.yaml
@@ -1,0 +1,15 @@
+---
+name:    'SUM20SP17'
+target:  'SUM20SP17'
+version: 005
+
+materials:
+
+  media:
+    # SUM
+    - name:         "Patch 5 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
+      archive:      SUM20SP17_5-80002456.SAR
+      checksum:     de769c993dccd1ac1e1653f3bd718c403e68914ed2631c248da129c0955e5c26
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000000946192023
+

--- a/SAP/archives/SUM20SP17_win_v0005ms/SUM20SP17_win_v0005ms.yaml
+++ b/SAP/archives/SUM20SP17_win_v0005ms/SUM20SP17_win_v0005ms.yaml
@@ -1,0 +1,14 @@
+---
+name:    'SUM20SP17'
+target:  'SUM20SP17'
+version: 005
+
+materials:
+
+  media:
+
+    - name:         "Patch 5 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
+      archive:      SUM20SP17_5-80002458.SAR
+      checksum:     023ce9daf7ce31b34ff5ec814a729360241adcb099d926f124603c142a73e8d7
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000000946252023


### PR DESCRIPTION
SUM20SP17 Patch 5 is now unavailable on SAP Marketplace.
Updated the links for SUM20SP17 Patch 6 in BoMs