### PR TITLE
Updating SUM20SP17 Patch 9 Links

### DIFF
--- a/SAP/SUM20SP17_latest/SUM20SP17_latest.yaml
+++ b/SAP/SUM20SP17_latest/SUM20SP17_latest.yaml
@@ -1,15 +1,15 @@
 ---
 name:    'SUM20SP17'
 target:  'SUM20SP17'
-version: 008
+version: 009
 
 materials:
 
   media:
     # SUM
-    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
-      archive:      SUM20SP17_8-80002456.SAR
-      checksum:     6de2ed4789f6f6c201c72752a7f315d99c030dc9c727c4af878cb48ba45addff
+    - name:         "Patch 9 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
+      archive:      SUM20SP17_9-80002456.SAR
+      checksum:     1de763d87dab547ff759821d749da7bed41f97ab02ec8bb9d1f506a6a48dddca
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000001091322023
+      url:          https://softwaredownloads.sap.com/file/0020000001151882023
 

--- a/SAP/SUM20SP17_win_latest/SUM20SP17_win_latest.yaml
+++ b/SAP/SUM20SP17_win_latest/SUM20SP17_win_latest.yaml
@@ -1,14 +1,14 @@
 ---
 name:    'SUM20SP17'
 target:  'SUM20SP17'
-version: 008
+version: 009
 
 materials:
 
   media:
 
-    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
-      archive:      SUM20SP17_8-80002458.SAR
-      checksum:     3a28411bf6affdd2d7793efe21cb1a3774d4de2ae26564b3e86ae3b0ca9483ba
+    - name:         "Patch 9 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
+      archive:      SUM20SP17_9-80002458.SAR
+      checksum:     4d9a3ee67d1f03fe76c75a8aa841e7738fdfb1a3ecbe9fcf5ce24f1954a442fd
       download:     false
-      url:          https://softwaredownloads.sap.com/file/0020000001090732023
+      url:          https://softwaredownloads.sap.com/file/0020000001151932023

--- a/SAP/archives/SUM20SP17_v0008ms/SUM20SP17_v0008ms.yaml
+++ b/SAP/archives/SUM20SP17_v0008ms/SUM20SP17_v0008ms.yaml
@@ -1,0 +1,15 @@
+---
+name:    'SUM20SP17'
+target:  'SUM20SP17'
+version: 008
+
+materials:
+
+  media:
+    # SUM
+    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Linux on x86_64)"
+      archive:      SUM20SP17_8-80002456.SAR
+      checksum:     6de2ed4789f6f6c201c72752a7f315d99c030dc9c727c4af878cb48ba45addff
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000001091322023
+

--- a/SAP/archives/SUM20SP17_win_v0008ms/SUM20SP17_win_v0008ms.yaml
+++ b/SAP/archives/SUM20SP17_win_v0008ms/SUM20SP17_win_v0008ms.yaml
@@ -1,0 +1,14 @@
+---
+name:    'SUM20SP17'
+target:  'SUM20SP17'
+version: 008
+
+materials:
+
+  media:
+
+    - name:         "Patch 8 for SOFTWARE UPDATE MANAGER 2.0 SP17 (Windows)"
+      archive:      SUM20SP17_8-80002458.SAR
+      checksum:     3a28411bf6affdd2d7793efe21cb1a3774d4de2ae26564b3e86ae3b0ca9483ba
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000001090732023


### PR DESCRIPTION
SUM20SP17 Patch 8 is now unavailable on SAP Marketplace. Updated the links for SUM20SP17 Patch 9 in BoMs