### PR TITLE
S4 hana 1909 and 2020 ISS 00 folders and files  addition

### DIFF
--- a/SAP/S41909ISS00_v0011ms/S41909ISS00_v0011ms.yaml
+++ b/SAP/S41909ISS00_v0011ms/S41909ISS00_v0011ms.yaml
@@ -1,0 +1,1209 @@
+---
+# Download time:  70 Minutes (Full - 63GB)
+# Download time:  43 Minutes (Partial - 38GB)
+#
+name:             "SAP S/4HANA 1909 ISS 00"
+filename:         'S41909ISS00_v00011ms'
+target:           'S/4 HANA 1909 ISS 00'
+version:          11
+platform:         "HANA"
+InstanceType:     "ABAP"
+
+product_ids:
+  dbl:       NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP
+  scs:       NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP
+  scs_ha:    NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAPHA
+  pas:       NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAP
+  pas_ha:    NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAPHA
+  app:       NW_DI:S4HANA1909.CORE.HDB.PD
+  app_ha:    NW_DI:S4HANA1909.CORE.HDB.ABAPHA
+  web:       NW_Webdispatcher:NW750.IND.PD
+  ers:       NW_ERS:S4HANA1909.CORE.HDB.ABAP
+  ers_ha:    NW_ERS:S4HANA1909.CORE.HDB.ABAPHA
+  generic:   NW_Users_Create:GENERIC.HDB.PD
+
+materials:
+  dependencies:
+    - name:     HANA_2_00_059_v0009ms
+    - name:     SWPM20SP16_latest
+    - name:     SUM20SP18_latest
+
+  media:
+
+  # SAPCAR 7.22
+    - name:         "SAPCAR 7.22; OS: Linux on x86_64 64bit"
+      archive:      SAPCAR_1115-70006178.EXE
+      checksum:     765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5
+      filename:     SAPCAR
+      permissions:  '0755'
+      url:          https://softwaredownloads.sap.com/file/0020000000098642022
+
+    # Kernel
+    - name:         "Kernel Part I ; OS: Linux on x86_64 64bit ; DB: Database independent"
+      archive:      SAPEXE_300-80004393.SAR
+      checksum:     f2b5d237664c3f4affa27eee72b3e34fe6daf1beeba386f67ac06be188b48fb5
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0020000001809672020
+
+    - name:         "Kernel Part II (777) ; OS: Linux on x86_64 64bit ; DB: SAP HANA database"
+      archive:      SAPEXEDB_300-80004392.SAR
+      checksum:     5080371029f927bb0f5ea3f9f34a38a8df31ea992498140fcafe033ec0280725
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0020000001809622020
+
+    # SAP Host Agent
+    - name:         "SAP HOST AGENT 7.21 SP51 ; OS: Linux on x86_64 64bit"
+      archive:      SAPHOSTAGENT51_51-20009394.SAR
+      checksum:     7a4dac4d1d57510b8a94d26a442b164f2b8580d01d8429e2427d1f613cd080a5
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0020000000363342021
+
+    # IGS
+    - name:         "Installation for SAP IGS integrated in SAP Kernel ; OS: Linux on x86_64"
+      archive:      igsexe_12-80003187.sar
+      checksum:     414ab4e14e3985e03dfbc1fcc8fdfe66b0972cfcbbacf80fc4b46c93f20a557e
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0020000001632902020
+
+    - name:         "SAP IGS Fonts and Textures"
+      archive:      igshelper_17-10010245.sar
+      checksum:     bc405afc4f8221aa1a10a8bc448f8afd9e4e00111100c5544097240c57c99732
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0020000000703122018
+
+    # DB Export
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_1.zip
+      checksum:     47f2355aa3a41efea260ffba9fb1d88b7716d42d337bbae7727550150ac356dc
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632352019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_2.zip
+      checksum:     fe1ecc302a46af0f74be2f2fa135f38a7d09e1bb6482ac36b0faa5316e053d85
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632802019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_3.zip
+      checksum:     5c22db1a220af7f2cc5d90e8d850ff528078ba6823fc85544c7d668c6a287e46
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633012019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_4.zip
+      checksum:     e724cc5c825276aa724c8137cc888c92f438045695ab0b415cda2645a64aea95
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633032019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_5.zip
+      checksum:     1bcf37d22909ed68a28519aa68ea92b7ed81eeb5d7be4ce4ce1c0f60909a87ab
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633052019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_6.zip
+      checksum:     e08ff082e15e03ffc86f38cca0fe58b2807546ad7872402e94e059d90c07604b
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633092019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_7.zip
+      checksum:     52af7674efdb544b63316fb9c9c59bd4be15ccebc224b8f0e4d505237d51a732
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633142019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_8.zip
+      checksum:     627db4ddc37ac46034022c0abd9efd2076c0269217d2caa0736c17183efd9d8c
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633192019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_9.zip
+      checksum:     7f798f08ab2170dd073d94d0c847665bb14ba1b9233a9ed223becea56f72e7cc
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633242019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_10.zip
+      checksum:     3d2bb02443a9ca5e326b76055a6e932e702a2e3347557b6e0c5f2e6aa3f5fb67
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632372019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_11.zip
+      checksum:     daa5e887436d943cd95c9864b7ba0aa5fb064c02d68d435d27ae4e31bdaa42ec
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632382019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_12.zip
+      checksum:     1860b110884f97ad2dbfd09c8cc39dd45e20952e7ee3bfddf87b849915b597a8
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632402019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_13.zip
+      checksum:     82ac509bdbef4d6cbceacb926613809a7972739bbaab75345a3dfec3c1d421c1
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632442019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_14.zip
+      checksum:     4877c6cb6f616ef9a22ed94048025921792a8c04e54808643459b9b20fd6ab75
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632472019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_15.zip
+      checksum:     db377a0456151e594f57745603088316c8d91c28b7ad4a61ffa27fb368fadfa8
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632502019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_16.zip
+      checksum:     f6a7e1b0df2ecfcdc107b09f21d5e00cb73e64d25cfca4a92e0e123ca810e685
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632562019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_17.zip
+      checksum:     a85d693d10bec340473f3136a6dbe20673209a15a0154a9b3da1c185cb800171
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632682019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_18.zip
+      checksum:     8bc95160c003e023bfb2b122e102ff9efc384d05dd1c24d5ff88b24d9315ef4e
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632732019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_19.zip
+      checksum:     1f86d2428b8ad9c421241bde55d97f8e5707235c3edfea97d53723e407a8acc8
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632782019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_20.zip
+      checksum:     e9a1425b8dddee1cb49a8bbbffcd1569cac0857822d0b094534936b5f1eec84c
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632832019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_21.zip
+      checksum:     3e016dbfbe965719578e999601f57eb88112954c1f906cf65149def39732c0f9
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632862019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_22.zip
+      checksum:     645ea88066171ffbc8da427254f7bb45919d18610e697afc81c7ca71fff56fed
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632902019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_23.zip
+      checksum:     e0e69bf2f0b2e3215656a8ed94d8067f971d5264815fa2a06a9c78961b801f22
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632932019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_24.zip
+      checksum:     22b915225787d717e530b13b06f9af2e0c316c664b49c63cce7483216142a890
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001632972019
+
+    - name:         "File on DVD"
+      archive:      S4CORE104_INST_EXPORT_25.zip
+      checksum:     04963a19c65a5b985a8c4aaf0c31c5adaf45aa8f2252dd5037b0a723d8eac45b
+      path:         download_basket
+      url:          https://softwaredownloads.sap.com/file/0030000001633002019
+
+    # MISC
+    - name:         "Predi. Analy. APL 2008 for SAP HANA 2.0 SPS03 and beyond ; OS: Linux on"
+      archive:      SAPPAAPL4_2008_0-80004547.ZIP
+      checksum:     4cd694252c228dfd158c273a8c0d0886f543d1a138698bb6f73445c398f22e2a
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000000410162020
+
+    - name:         "SP12 Patch7 for UMML4HANA 1"
+      archive:      HANAUMML12_7-70001054.ZIP
+      checksum:     c26328f2fd99eb8188aa4ff66d682818a6c402bc37efd8631ed166ad585ca44d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0020000000665292023
+
+    # SPAM
+    - name:         "SPAM/SAINT Update - Version 754/0077"
+      archive:      KD75477.SAR
+      checksum:     9c5b28b704d0ef0a9c4a63b9511891c65bef53842b1c78e2ac0a6191a18a36e7
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000216172021
+
+    # Support Packs
+    - name:         "Attribute Change Package 18 for EA-HR 608"
+      archive:      EA-HR608.SAR
+      checksum:     5d709769878a6f53ca658ada1fe272b1d776619cc6f29042217786362659d0bc
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000059642016
+
+    - name:         "Attribute Change Package 28 for GBX01HR5 605"
+      archive:      GBX01HR5605.SAR
+      checksum:     9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000033172015
+
+    - name:         "Attribute Change Package 19 for GBX01HR 600"
+      archive:      GBX01HR600.SAR
+      checksum:     92e966f40681b11bad6c7bcd068387fdcf196974592aca6e0fae01267ff8a75e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000029982015
+
+    - name:         "Attribute Change Package 01 for IS-UT 804"
+      archive:      IS-UT804.SAR
+      checksum:     facdf7c19810c494faf35805931cd8e5def1da971db0278b738577843e4e9cd9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001230572020
+
+    - name:         "S4CORE 104: SP 0001"
+      archive:      K-10401INS4CORE.SAR
+      checksum:     7f6aa90421db834f97631f8b18dee88938d4e5edc16006dee619d69feb4577d6
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285802019
+
+    - name:         "S4COREOP 104: SP 0001"
+      archive:      K-10401INS4COREOP.SAR
+      checksum:     f62e7f0da90de418f5bd9808003f79d5c8df01c819b6cc61215cc53a5fecc71b
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285822019
+
+    - name:         "S4FND 104: SP 0001"
+      archive:      K-10401INS4FND.SAR
+      checksum:     c916ddf0afc0aae875036bab7bf6067eaac4e203c761904395db0f6e55f3910f
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285842019
+
+    - name:         "S4CORE 104: SP 0002"
+      archive:      K-10402INS4CORE.SAR
+      checksum:     f32fa0f494d7220a4ffb69c546fbf5f53610ce7c305f0095bff290777f9ef370
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552382020
+
+    - name:         "S4COREOP 104: SP 0002"
+      archive:      K-10402INS4COREOP.SAR
+      checksum:     a4ec6f7be63b15ee1d1a0af3138b1b05d08a1aabfdb7a53cfbc8c9aa40ae59e9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552392020
+
+    - name:         "S4FND 104: SP 0002"
+      archive:      K-10402INS4FND.SAR
+      checksum:     a3dce2abd528dc056589ebed7271fb8670c99a4ed208dedb2c7b7b906aaabbce
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552402020
+
+    - name:         "S4CORE 104: SP 0003"
+      archive:      K-10403INS4CORE.SAR
+      checksum:     0bf093325edc3bb08530a5f06b8e67718506eaa9e0a4740dad07273e81d644bf
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001737422020
+
+    - name:         "S4COREOP 104: SP 0003"
+      archive:      K-10403INS4COREOP.SAR
+      checksum:     dcd07afbf73d0cd8b70eec93e3f51fba423922a79d3c77bcd699e1fbd372dee0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697582020
+
+    - name:         "S4FND 104: SP 0003"
+      archive:      K-10403INS4FND.SAR
+      checksum:     c3d3d3afb1b2a957131d49cf6524be575bd74e24d2da892375886d25cb18afd2
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697792020
+
+    - name:         "S4CRM 204: SP 0001"
+      archive:      K-20401INS4CRM.SAR
+      checksum:     371566483a5878a31b0f5386d5bf6f096eec25bb4e3361562bf5c51ce4b1b48e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285852019
+
+    - name:         "S4CRM 204: SP 0002"
+      archive:      K-20402INS4CRM.SAR
+      checksum:     c0a016d6d62953f131f4bbebef80cb68da68aaa23f11ae35cfdb3bea7e7097b9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552412020
+
+    - name:         "S4CRM 204: SP 0003"
+      archive:      K-20403INS4CRM.SAR
+      checksum:     86d0b7fdb964af5948612e87fb98cbaf9911906425e9f6e3c8048da63656b1e8
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697592020
+
+    - name:         "UIBAS001 500: SP 0001"
+      archive:      K-50001INUIBAS001.SAR
+      checksum:     a8673301a6989af16579a763e71e00aaf7f01daad779147cc62e2fc7e7ed4600
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000032482020
+
+    - name:         "UIBAS001 500: SP 0002"
+      archive:      K-50002INUIBAS001.SAR
+      checksum:     a1be836a78da25dca2ec6eb11c62929c35e8bc4cb870e1162438dbe6676847c1
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000754732020
+
+    - name:         "UIBAS001 500: SP 0003"
+      archive:      K-50003INUIBAS001.SAR
+      checksum:     482f39a6de94d3276557ee0ab153132b6743b7aeed0453a9284a8437914bf054
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001565882020
+
+    - name:         "UIBAS001 500: Add-On Installation"
+      archive:      K-500AGINUIBAS001.SAR
+      checksum:     0265fdf4f3663d6dbef5bc818d9405980757922d165032ba8a39663b48dfa923
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001171932019
+
+    - name:         "GBX01HR 600: SP 0014"
+      archive:      K-60014INGBX01HR.SAR
+      checksum:     e9d244a937deac3940882ec794478ad5a4be7677ec0dc0b5c7fa2d6e32013fff
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001255172019
+
+    - name:         "GBX01HR 600: SP 0015"
+      archive:      K-60015INGBX01HR.SAR
+      checksum:     8164c3a942d23063362fdf51d18b67319e59d2758ed10642a318fb4caf37de13
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001714692019
+
+    - name:         "GBX01HR 600: SP 0016"
+      archive:      K-60016INGBX01HR.SAR
+      checksum:     669fbd22858dd476fcffb215a2f92747becd525047e3e192f6af26c9577c88b0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000334222020
+
+    - name:         "GBX01HR 600: SP 0017"
+      archive:      K-60017INGBX01HR.SAR
+      checksum:     162a8ea4e4ffd2f2655059adf9e622ad7032cc4826bfd820976a93cae1150b63
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000930752020
+
+    - name:         "GBX01HR5 605: SP 0011"
+      archive:      K-60511INGBX01HR5.SAR
+      checksum:     1b44fee0533e4beee5f0f3f72d32f6458ce52e43ebd6bef4abbac5757ddb2c99
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001303782019
+
+    - name:         "GBX01HR5 605: SP 0012"
+      archive:      K-60512INGBX01HR5.SAR
+      checksum:     206f35119c9471c06ffe6b539d12287db671ef83c4e4a3bbfb60016871900b42
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001713732019
+
+    - name:         "GBX01HR5 605: SP 0013"
+      archive:      K-60513INGBX01HR5.SAR
+      checksum:     4186f2155554253efed1f8d236a3379dfa017593624f571d289dfed2d67dd5a4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000334292020
+
+    - name:         "GBX01HR5 605: SP 0014"
+      archive:      K-60514INGBX01HR5.SAR
+      checksum:     ba2c4b86cfd20f483bb765d9f7c9073a03d38499c0727c7c66a37d4fab788ea4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000930742020
+
+    - name:         "EA-HR 608: SP 0070"
+      archive:      K-60870INEAHR.SAR
+      checksum:     dcd882a6333cb09e0a2718cb8ee31a0919372aec132e2fba781e91590f0dfe61
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001408362019
+
+    - name:         "EA-HR 608: SP 0071"
+      archive:      K-60871INEAHR.SAR
+      checksum:     02c0add5e8b2d870aec18104fd144ba16fa37247777021ea3e71e10fd21fbe27
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001610262019
+
+    - name:         "EA-HR 608: SP 0072"
+      archive:      K-60872INEAHR.SAR
+      checksum:     e8e2df3ab180681e9d5333bfd5bc2b0290ab598d26608ce491092b837395f4f5
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001804692019
+
+    - name:         "EA-HR 608: SP 0073"
+      archive:      K-60873INEAHR.SAR
+      checksum:     5144e869ec51949f0dd38544be0364a87744f7320ae6d43dad74ad89c82adc0d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001982812019
+
+    - name:         "EA-HR 608: SP 0074"
+      archive:      K-60874INEAHR.SAR
+      checksum:     e72b32b57f0819235073ac77a1460ba6b6fb7c585bbd1440489799b54e9e9964
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002175012019
+
+    - name:         "EA-HR 608: SP 0075"
+      archive:      K-60875INEAHR.SAR
+      checksum:     1815d01187fca7b32a7fe4da12cdfc00740c4f0952ddf24b96dae11c14ebf53e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002263012019
+
+    - name:         "EA-HR 608: SP 0076"
+      archive:      K-60876INEAHR.SAR
+      checksum:     b907a0c86906a434b68db4d79982fd1df858dae8cf30895cb2b6ca85eba678ef
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000079822020
+
+    - name:         "EA-HR 608: SP 0077"
+      archive:      K-60877INEAHR.SAR
+      checksum:     454f537fc4a605e1b6c3a8ae2d88ced8eed1e8b53c46639cc1fb4a074919518f
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000194132020
+
+    - name:         "EA-HR 608: SP 0078"
+      archive:      K-60878INEAHR.SAR
+      checksum:     b86590bb5e6394e06290a329b9e350c137c9e3846de1abb709adc7412282e6a4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000372672020
+
+    - name:         "EA-HR 608: SP 0079"
+      archive:      K-60879INEAHR.SAR
+      checksum:     5a75006525601fdb895cee7f26a1b5c0bc06b3c1ba5ea998e8c9e5f274bc3e30
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000565012020
+
+    - name:         "EA-HR 608: SP 0080"
+      archive:      K-60880INEAHR.SAR
+      checksum:     d20577967fe4929416e01b4d687d11d0ebe5b5c851661a551dd7c21a7c45f8f2
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000808832020
+
+    - name:         "EA-HR 608: SP 0081"
+      archive:      K-60881INEAHR.SAR
+      checksum:     1ab7fae03e983a486324134cac87da629c15e7f977494ba9b5832ec1b90ffa66
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000956792020
+
+    - name:         "EA-HR 608: SP 0082"
+      archive:      K-60882INEAHR.SAR
+      checksum:     01596ecf68e15daf895cf441758be760cc79559b3c06bb0823fad9fff212f451
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001129572020
+
+    - name:         "EA-HR 608: SP 0083"
+      archive:      K-60883INEAHR.SAR
+      checksum:     2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001324782020
+
+    - name:         "EA-HR 608: SP 0084"
+      archive:      K-60884INEAHR.SAR
+      checksum:     76561e41400cb15c2e0a11aab41b4e15be0362e78bf322a327947caa166bedb0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001507772020
+
+    - name:         "ST-PI 740: SP 0012"
+      archive:      K-74012INSTPI.SAR
+      checksum:     0f385ce50d6119fca8457aaaea49f7337b5315993d930a16403e04db713f083b
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002162182019
+
+    - name:         "ST-PI 740: SP 0013"
+      archive:      K-74013INSTPI.SAR
+      checksum:     e1270d366de17b67ab2f971195da4fa944509274eea778e664b8050b078d0c45
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000660652020
+
+    - name:         "ST-PI 740: SP 0014"
+      archive:      K-74014INSTPI.SAR
+      checksum:     f1a9058c623360d576469c51a74e5e649b7055bcac200c5b0f8165801a189048
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001984822020
+
+    - name:         "SAP_BASIS 754: SP 0001"
+      archive:      K-75401INSAPBASIS.SAR
+      checksum:     4a40cae7ba9a17d20e77817cbdc7d64d6136503e002d6c9ef4329a4118e9ec13
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002197582019
+
+    - name:         "SAP_BW 754: SP 0001"
+      archive:      K-75401INSAPBW.SAR
+      checksum:     f9904680716d3381089fa2135ab53a2ef040c4c4cbdd1356194a1b6155d3eb06
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002197592019
+
+    - name:         "SAP_GWFND 754: SP 0001"
+      archive:      K-75401INSAPGWFND.SAR
+      checksum:     56c3260c3d9a4441c1fe3a1480d9e1f96c47eb31ab9e88d526fa2e3657cda65a
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002197602019
+
+    - name:         "SAP_UI 754: SP 0001"
+      archive:      K-75401INSAPUI.SAR
+      checksum:     212fc7d928ced7bd9a9c1e587f65457a6e40bb2bb49527ea88834e4f32b3639e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001661402019
+
+    - name:         "SAP_BASIS 754: SP 0002"
+      archive:      K-75402INSAPBASIS.SAR
+      checksum:     dd37c37ee7eb4c5e5760f1ef7f15b36045c0783be061f95b718d962f27464d66
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000380842020
+
+    - name:         "SAP_BW 754: SP 0002"
+      archive:      K-75402INSAPBW.SAR
+      checksum:     f5121f9670a31647044a79434d648221b19aca18e81b59a3ac63a0f7c6d55cc3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000380852020
+
+    - name:         "SAP_GWFND 754: SP 0002"
+      archive:      K-75402INSAPGWFND.SAR
+      checksum:     c5509e74a3c3e2324c503e3e0ad58304c179020db7b33e59b92d6be255b2ac2d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000380862020
+
+    - name:         "SAP_UI 754: SP 0002"
+      archive:      K-75402INSAPUI.SAR
+      checksum:     3a4bcfd61b3015083e5e28a6db294c9c09277778b49d0259debebbf63443996d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002197612019
+
+    - name:         "SAP_BASIS 754: SP 0003"
+      archive:      K-75403INSAPBASIS.SAR
+      checksum:     f3eb40b032a37a8b43089a2eb9a97390bb3a7c6025fc87636932c5ac9aac57b9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001633452020
+
+    - name:         "SAP_BW 754: SP 0003"
+      archive:      K-75403INSAPBW.SAR
+      checksum:     67bd42e1e4fbde34c7a4498786ae830ec7c0e4bfa0318cb24b8a4ef661015da9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001523722020
+
+    - name:         "SAP_GWFND 754: SP 0003"
+      archive:      K-75403INSAPGWFND.SAR
+      checksum:     ce32d2ba2c68c4c7950f0a26274d155d763e545ac4c431107986ed88f26a7486
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001633462020
+
+    - name:         "SAP_UI 754: SP 0003"
+      archive:      K-75403INSAPUI.SAR
+      checksum:     0a7640a5a2174b0dee45810466473932265f67bf6b0aa6e355930315513379c3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000380882020
+
+    - name:         "SAP_UI 754: SP 0004"
+      archive:      K-75404INSAPUI.SAR
+      checksum:     260318324bf29dff72a59cac8ce4d607803ba27abfcfd30e999b9b0bc373bb9c
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000876572020
+
+    - name:         "SAP_UI 754: SP 0005"
+      archive:      K-75405INSAPUI.SAR
+      checksum:     a493ff19b33d555960d10e53657f5803a21bdf1c7ca3b91345da24afa5671e6e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001523772020
+
+    - name:         "SAP_ABA 75E: SP 0001"
+      archive:      K-75E01INSAPABA.SAR
+      checksum:     52fd5f06d3a772cefb92eb573a0daa45363e81c6b488fb7cdae44c75974bb416
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002197622019
+
+    - name:         "SAP_ABA 75E: SP 0002"
+      archive:      K-75E02INSAPABA.SAR
+      checksum:     db2a316859caa2295cd33fb269e19309c45baa575a03c8eaef297ed784ca3adc
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000380892020
+
+    - name:         "SAP_ABA 75E: SP 0003"
+      archive:      K-75E03INSAPABA.SAR
+      checksum:     2ddc9648351d74441e0a2b9da6d4f034c53ebb70fcce8454e3467d5daede2c00
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001633472020
+
+    - name:         "EA-DFPS 804: SP 0001"
+      archive:      K-80401INEADFPS.SAR
+      checksum:     134962523391b90d0ba2c7150da77a7cfe7b51f74c1f0c2ddf6dcf65f415f403
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285862019
+
+    - name:         "EA-PS 804: SP 0001"
+      archive:      K-80401INEAPS.SAR
+      checksum:     0fb44f4baa23e6b75c562372d104cea8808b0be57f8d45dcd82e2a565fc15fd1
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285882019
+
+    - name:         "FI-CAX 804: SP 0001"
+      archive:      K-80401INFICAX.SAR
+      checksum:     adf95847f353bc39829917f37d30222f9a4d581feb772b67c4bdc81d16e58408
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285892019
+
+    - name:         "INSURANCE 804: SP 0001"
+      archive:      K-80401ININSURANC.SAR
+      checksum:     b80fa5a385606abafc5db5c2b15e1e0ca70e90040e8a5c49762668c54dbb1201
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285912019
+
+    - name:         "IS-OIL 804: SP 0001"
+      archive:      K-80401INISOIL.SAR
+      checksum:     b0b0871349f539596bb2f902905fa79ceffc4beb46cdb4c43250d4b900a88b2a
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285942019
+
+    - name:         "IS-PRA 804: SP 0001"
+      archive:      K-80401INISPRA.SAR
+      checksum:     f61e60167772c392090463554b030c94b79e6fb8617e0c3ed24b560d7e37815b
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285952019
+
+    - name:         "IS-PS-CA 804: SP 0001"
+      archive:      K-80401INISPSCA.SAR
+      checksum:     819ece1e40ba96737f34621a5a5447a6ebb5707283c38e584dad9ed1bb50d129
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285962019
+
+    - name:         "IS-UT 804: SP 0001"
+      archive:      K-80401INISUT.SAR
+      checksum:     60e6327dd6cc733dc8b83db1a485935cc5e0e93a0725a750b967eaeea4f49c5d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285972019
+
+    - name:         "MDG_APPL 804: SP 0001"
+      archive:      K-80401INMDGAPPL.SAR
+      checksum:     ca28956db4f29f42804eb7538dd9aed8888edbccfbcfed4434377ed37a3576d4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285982019
+
+    - name:         "MDG_FND 804: SP 0001"
+      archive:      K-80401INMDGFND.SAR
+      checksum:     28a3d8d7a55febe6ddbe676e621a5e4b5e62595adec20a031a77a05ae0954899
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002285992019
+
+    - name:         "MDG_UX 804: SP 0001"
+      archive:      K-80401INMDGUX.SAR
+      checksum:     8ed2ba33ee1f0f5c26b4aa1b75f0fde35b0739f532abb55ffb09648d00f5ec6b
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002286002019
+
+    - name:         "EA-DFPS 804: SP 0002"
+      archive:      K-80402INEADFPS.SAR
+      checksum:     9c9c97a21f8f48e7f2507af21cd8d17e8a8a619d753f370e1856cd68b2e6e2d1
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552422020
+
+    - name:         "EA-PS 804: SP 0002"
+      archive:      K-80402INEAPS.SAR
+      checksum:     0609a986359d65c0a50e584a42ce37252bbb2a92f00943c737f2ee18926e9a77
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552432020
+
+    - name:         "FI-CAX 804: SP 0002"
+      archive:      K-80402INFICAX.SAR
+      checksum:     e4419269cceea539165711739e4739ed72caaa59bbc244b9a4bc299623434dbd
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552452020
+
+    - name:         "INSURANCE 804: SP 0002"
+      archive:      K-80402ININSURANC.SAR
+      checksum:     7956c069000296f2ff72f2ce8b56941ba4f6c52731ba0ddbf0930fab484820cb
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552462020
+
+    - name:         "IS-OIL 804: SP 0002"
+      archive:      K-80402INISOIL.SAR
+      checksum:     1b5ec2d2fa6720d43f206352af721c6e132c17c8c72173cff70d76233eeb45cb
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552472020
+
+    - name:         "IS-PRA 804: SP 0002"
+      archive:      K-80402INISPRA.SAR
+      checksum:     219cf309cb17c76a9693b38815d58e0f773e1e63ccf995f4ef2d38e437d0fa7b
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552482020
+
+    - name:         "IS-PS-CA 804: SP 0002"
+      archive:      K-80402INISPSCA.SAR
+      checksum:     14883e8503810f1eb4062468c4c01af55ec07f8db4fb133fc2823b6a00c961b0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552492020
+
+    - name:         "IS-UT 804: SP 0002"
+      archive:      K-80402INISUT.SAR
+      checksum:     22fb4ca3ababdcad8f4fa36e71aef543123067e69ec3d86a4d54b4dec8b3e2f1
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552502020
+
+    - name:         "MDG_APPL 804: SP 0002"
+      archive:      K-80402INMDGAPPL.SAR
+      checksum:     4b7ff080b9c34f3a2785d51718876694e8f26fca801ec316605fccf9beb796cd
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552512020
+
+    - name:         "MDG_FND 804: SP 0002"
+      archive:      K-80402INMDGFND.SAR
+      checksum:     f92830011867efb630160110bc98c473372fb1c911d4d152e95349ff95a3c88e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552522020
+
+    - name:         "MDG_UX 804: SP 0002"
+      archive:      K-80402INMDGUX.SAR
+      checksum:     74a8fb3b2998b468de6d3534001e60f028fea3b65afb68221dafdc3396287816
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000552532020
+
+    - name:         "EA-DFPS 804: SP 0003"
+      archive:      K-80403INEADFPS.SAR
+      checksum:     00922941bcde4070c2b482c66c94fc51067ed211226e0ffbd49adb5938980b0d
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697602020
+
+    - name:         "EA-PS 804: SP 0003"
+      archive:      K-80403INEAPS.SAR
+      checksum:     fe9eabd2528d652f95e81a791df0f0b941bd433ec9f57bcc9e7115fbfb3634f7
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697612020
+
+    - name:         "FI-CAX 804: SP 0003"
+      archive:      K-80403INFICAX.SAR
+      checksum:     c3e06fe63b0fa7f70c8eca2614a763eac09b23dd6dc2bfb3f28d93c5cd55ac68
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697622020
+
+    - name:         "INSURANCE 804: SP 0003"
+      archive:      K-80403ININSURANC.SAR
+      checksum:     157de1d8fad077c700e6a17e44cf8a60b5ff047aa2aa237068340dbc986aee29
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697632020
+
+    - name:         "IS-OIL 804: SP 0003"
+      archive:      K-80403INISOIL.SAR
+      checksum:     ba996c64d623d18ff5abf3fcc6929a9edd8ec64fdf55d6cacfe5a49e118cee15
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697662020
+
+    - name:         "IS-PRA 804: SP 0003"
+      archive:      K-80403INISPRA.SAR
+      checksum:     65df430410ce34acf2f1d27dd443e760a5aa0e14a29d25a9ad12a6fe3e3af5dc
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697682020
+
+    - name:         "IS-PS-CA 804: SP 0003"
+      archive:      K-80403INISPSCA.SAR
+      checksum:     bae37477708c822a3aa500c5889edc9557b6dcaeee9cc5fd5023e33e564bd1ce
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697692020
+
+    - name:         "IS-UT 804: SP 0003"
+      archive:      K-80403INISUT.SAR
+      checksum:     42f4f4c2ee96ddb330f29be5d255a9d6411664772ad518fbe3632954d31865a9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697702020
+
+    - name:         "MDG_APPL 804: SP 0003"
+      archive:      K-80403INMDGAPPL.SAR
+      checksum:     6d7bd82d8f913a45ad93bda97fda5b54962477762a302b4df3b0685d0f65d50f
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697722020
+
+    - name:         "MDG_FND 804: SP 0003"
+      archive:      K-80403INMDGFND.SAR
+      checksum:     5737bf4bf8bb4fb38356c668efe22bc134ac4087f4511f78ae059b2c5a8361c5
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697732020
+
+    - name:         "MDG_UX 804: SP 0003"
+      archive:      K-80403INMDGUX.SAR
+      checksum:     d6b34b9d7780d42aac951022f642b051e6b2db7f137a6ebe87e43838fd03a6c6
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001697742020
+
+    - name:         "SAP_HR 608: SP 0070"
+      archive:      KE60870.SAR
+      checksum:     bbe6b10223ecc3b73ff49fc2ae34c8f4e66321917a7468f79a65db8043109afd
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001408342019
+
+    - name:         "SAP_HR 608: SP 0071"
+      archive:      KE60871.SAR
+      checksum:     2285247c29bb457e6802c14acfaa334a877417064da836882c0460d8aa69ad07
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001610232019
+
+    - name:         "SAP_HR 608: SP 0072"
+      archive:      KE60872.SAR
+      checksum:     f0778dbe45ca4c85296e48fe6a02302c971d4b5e60286c354bf633128efd6dd5
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001804682019
+
+    - name:         "SAP_HR 608: SP 0073"
+      archive:      KE60873.SAR
+      checksum:     eaf731726657122048bba3cb00fe7cb214c8708b4fa331670bee4feb202457b9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001982832019
+
+    - name:         "SAP_HR 608: SP 0074"
+      archive:      KE60874.SAR
+      checksum:     f9f64e20e7946b230be7517fa67e6b25f3d3ecab9c5f360c88ab6b398f10a549
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002175002019
+
+    - name:         "SAP_HR 608: SP 0075"
+      archive:      KE60875.SAR
+      checksum:     f3bf922a4832bb09ccd53d1f196ab0de4e34f6f7987467e147f03a0c146c373a
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000002263022019
+
+    - name:         "SAP_HR 608: SP 0076"
+      archive:      KE60876.SAR
+      checksum:     0059e80ae0861a7f2d82cf4db938ec48dc3d374296ae328513f0a878400952d3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000079812020
+
+    - name:         "SAP_HR 608: SP 0077"
+      archive:      KE60877.SAR
+      checksum:     87c482a7331a034b0042c8cba67dd9fc300ae89fd4cb99731a1bf93a0262da31
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000194122020
+
+    - name:         "SAP_HR 608: SP 0078"
+      archive:      KE60878.SAR
+      checksum:     244eec42e51e3e228c25bbdb1402db821a9bfecb6a08c756a2091f3768eb3498
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000372662020
+
+    - name:         "SAP_HR 608: SP 0079"
+      archive:      KE60879.SAR
+      checksum:     522e3e92ae21bcb94416b516633cf33c6e615bec45c4b202165cd5851e50cf32
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000565022020
+
+    - name:         "SAP_HR 608: SP 0080"
+      archive:      KE60880.SAR
+      checksum:     1270113496d36d07a163adca0050ada1ae55a75765641f216bd562718b9662a3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000801662020
+
+    - name:         "SAP_HR 608: SP 0081"
+      archive:      KE60881.SAR
+      checksum:     2ac014c6fccbba904c53560e66c5ba8fca7521e2bf2112462f0396ce7baa6eb7
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000956782020
+
+    - name:         "SAP_HR 608: SP 0082"
+      archive:      KE60882.SAR
+      checksum:     35259f476b36f971e752d58fa1e2e5e1a704e471e68ea6daa813d49fe8613bef
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001129562020
+
+    - name:         "SAP_HR 608: SP 0083"
+      archive:      KE60883.SAR
+      checksum:     02b35c133b2aa72887085cbbf9c876d628077ed2da37cda311c204b6c88aa1a4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001324772020
+
+    - name:         "SAP_HR 608: SP 0084"
+      archive:      KE60884.SAR
+      checksum:     77e7373357923c82612850831630ce10090b4ab1cc6aa3bef39eb50ee40141d8
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001507762020
+
+    - name:         "Servicetools for SAP Basis 731 and higher"
+      archive:      KITAB9X.SAR
+      checksum:     18f33b6c68317398932c9f54e331e9c370c2e320b57cc23b2e805893cd1c4684
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001910402019
+
+    - name:         "Attribute Change Package 04 for S4CORE 104"
+      archive:      S4CORE104.SAR
+      checksum:     94d12af4fec95b8c06aa32065331526969b553127535bc3cd5a9ca032bbd5427
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001225062020
+
+    - name:         "Attribute Change Package 01 for S4COREOP 104"
+      archive:      S4COREOP104.SAR
+      checksum:     923a09b96073366ac37255c460f83344290e0577e0812589d5c62d811d72c44e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001469192020
+
+    - name:         "Attribute Change Package 05 for SAP_BASIS 754"
+      archive:      SAP_BASIS754.SAR
+      checksum:     38ba3f82157e32a75429b02dbf34e7e8299e85f012e955e5fbfe914ea53e9d84
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001496942020
+
+    - name:         "Attribute Change Package 37 for SAP_HR 608"
+      archive:      SAP_HR608.SAR
+      checksum:     21055a344d47909f65f40a1c6febf7268650ea2623e6bfbef2f68b607388d469
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000249512014
+
+    - name:         "Attribute Change Package 07 for SAP_UI 754"
+      archive:      SAP_UI754.SAR
+      checksum:     cc0d69286eaec4bd21510984b06f02368df2a84c34e5080c72305bae1498dae4
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000031692020
+
+    - name:         "Attribute Change Package 23 for SRA004 600"
+      archive:      SRA004600.SAR
+      checksum:     ae231eadcb360d1be79959357036814874eefa92d7988c5a2c65d9c26cc173af
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000060132013
+
+    - name:         "Attribute Change Package 02 for ST-A/PI 01T_731"
+      archive:      ST-API01T_731.SAR
+      checksum:     baf19ad903c37af6072895e102566a4eaafbee504345666cff4a37d6d40bec2c
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000001964502018
+
+    - name:         "Attribute Change Package 56 for ST-PI 740"
+      archive:      ST-PI740.SAR
+      checksum:     564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0010000000297212015
+
+    # Languages
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_AR.SAR
+      checksum:     062d30f6c987df6cc537c019af5c85631344495fee9b6a8389ff8cdc36ad87c6
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631652019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_BG.SAR
+      checksum:     62a720ae2a783a41f4e1305bcb1c1865a57110c5695850a5ed82f8bbe37684ce
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631662019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_CA.SAR
+      checksum:     b3f0a54e833087bb53bf03fddf9277381f7e82162636327d72d8223af5fcd817
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631682019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_CS.SAR
+      checksum:     a307ac9d756ec6ecddae853a79411cc784a04415dee6793fb9b12cb00f0239bb
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631692019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_DA.SAR
+      checksum:     d04382d1a3204370fc4fe4dd82d02ed3e085651d581c1eebb7ad1e8533c1c07f
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631702019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_DE.SAR
+      checksum:     c33b28a84517834628742dd7fb82aed0cf6d3d494366e9e68e49a6c35a99c845
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631712019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_EL.SAR
+      checksum:     100aba185b1931bee78521387dace04dff74ab5a6260997a31b984d1ef7f3a38
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631722019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_EN.SAR
+      checksum:     3847815f47e14e607fab822156ce514a065d4769c14a491056498d0f52107fa3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631732019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_ES.SAR
+      checksum:     842edbd5bd4e0eecc6d89404dcc9d76b7d593b84a4bdf9213b0be329a700a934
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631762019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_ET.SAR
+      checksum:     85fe5aab5b6d7c538f7c261f62d9e0cf548f107fef88d4caab66eb60ebbf43b0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631772019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_FI.SAR
+      checksum:     c394e6f765969d15900f88a58887d406789a9f52c4e3f3e2b8ef3b7683600a2f
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631792019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_FR.SAR
+      checksum:     9c8c5efeab4194f685365cfa1d57cda9c12b8b63638dbc7cdd9eedff5444669e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631802019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_HE.SAR
+      checksum:     a7829b8a9f9a150ba0793b8ce4e633dbe64902f615345415a1ece4fe150033d3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631812019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_HI.SAR
+      checksum:     c80be7614025ab16ab6c390476dd105b8e02cc7c819bd40f50007e4b88d107c3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631832019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_HR.SAR
+      checksum:     76b888a06e82f76bc9291fc9227f63f36cf1b00d6afe7e9bdf721027e6923710
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631842019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_HU.SAR
+      checksum:     76d682d992085200fcd20a0c47121658cc4d69c665b0c1d8779df74df4674775
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631852019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_IT.SAR
+      checksum:     a69564ca155be5a28ea6e594cbdbf28b47590fafff92b86d6348faeab3cea091
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631862019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_JA.SAR
+      checksum:     82ae0bb2db0843d998174bf6696bb6b32ea46d16ae86f7beff567011adc88c05
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631872019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_KK.SAR
+      checksum:     2ed0f0d0b391a39e3735e1e05491a6a76208d832175d735bc114372368f58e32
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631882019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_KO.SAR
+      checksum:     05625ba691e48abee8468ada32a71fad8d6da7c666b6af3e7cec1ddbe0bfb432
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631892019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_LT.SAR
+      checksum:     5e76e2aafd94c5992283169bf4348fb0c4e50dc52f06bae3c02763b91a18f8e9
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631902019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_LV.SAR
+      checksum:     48afe6ba1f54a1a8dc9219d027160a453b78e6ff6bf2db3b98538f28b57ee201
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631912019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_MS.SAR
+      checksum:     f90b8e287d04bd7bd5ea3239d04f6d9b8bb5dc37e60837339e9af297837067e6
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631932019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_NL.SAR
+      checksum:     11552aa51ee46b87c34e98aa5bcab6d54200a476ef4b5686088d64cc6bbb39d0
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631942019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_NO.SAR
+      checksum:     55f74aceef8e3bcc6326d1771a2eb60b7e1bbc962ed50a1be21f13088d16b2f3
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631952019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_PL.SAR
+      checksum:     9db9d3b1fdc89239b9757e1ff1293f498a1404b7e30ea5fcb34b0e35125232dd
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631962019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_PT.SAR
+      checksum:     4f7d00f6ff2f2faa94c14bca18462e87c657fb1161a46c84fccd091927f28f5c
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631972019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_RO.SAR
+      checksum:     e734437d105322ae55489e8de59d92a92bcfd2c52f22424b7b7bd96ca4915465
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001631982019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_RU.SAR
+      checksum:     c31710b771641c656094ceeea22b60ec70321e8dadc8f59b3b4fe7049426c27c
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632002019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_SH.SAR
+      checksum:     bca60b4f47acc624e0e3ef2031d146d98d4f3649e8f8fe6eb63ede5f9b2d9288
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632012019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_SK.SAR
+      checksum:     117ccdcc2a29b993c1440186bd15283bd8eac7ab54c328f3a8df28ef4a41210e
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632022019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_SL.SAR
+      checksum:     54b7eed1b6686e0e6eb77c09e840d16b95fe0337202ff980141308c7ca7b4743
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632032019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_SV.SAR
+      checksum:     039648ae60380bf26997820e1a73a011d6d06d5a2e0e70927d0067c511371e81
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632042019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_TH.SAR
+      checksum:     94863d1b66b5dad9eb8a9fc493425e07a9e733848f02b016cc0b3fbed5913492
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632052019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_TR.SAR
+      checksum:     e54b6dfc5ff58d1527fe18281971e8e65ee600cc5e6c5fac75930a0a41b38149
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632072019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_UK.SAR
+      checksum:     1f7441bff87a46d6950a592ec70abe7f63bfbcb6c93c12bc51d20830a4c7ad2a
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632092019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_VI.SAR
+      checksum:     70e4d55c67b5413132ec2e8d8cc330205f694ea5ec236b3c3ce01f5d52b3a9da
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632102019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_ZF.SAR
+      checksum:     a442372d7332b55cbc31ea868e890ac27d1835589e4a8ef7e68dd3787cfbe4c5
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632112019
+
+    - name:         "File on DVD"
+      archive:      S4HANAOP104_ERP_LANG_ZH.SAR
+      checksum:     eb64fc54d91003a779e8bb7908dce9385b244ccd277738081a21e7c9e97b4fa2
+      download:     false
+      url:          https://softwaredownloads.sap.com/file/0030000001632152019
+
+# Web Dispatcher
+
+    - name:                            "Support Package SAP WEB DISPATCHER 7.81 Linux on x86_64 64bit"
+      archive:                         SAPWEBDISP_SP_110-70005393.SAR
+      checksum:                        706e5f4eab5d8a3573c3cc2bf6695562b8c71c59b5079e2f7e7b8afb283ee5fc
+      url:                             https://softwaredownloads.sap.com/file/0020000000314542021
+      download:                        true
+
+...

--- a/SAP/S41909ISS00_v0011ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -1,0 +1,305 @@
+[General]
+
+# Location of Installation Medium
+component_medium=
+
+# Comma separated list of component directories
+component_dirs=
+
+# Use single master password for all users, created during installation ( Default: n )
+use_master_password=n
+
+# Directory root to search for components
+component_root={{ _rsp_component_root }}
+
+# Skip all SAP Host Agent calls ( Default: n )
+skip_hostagent_calls=n
+
+# Remote Execution ( Default: ssh; Valid values: ssh | saphostagent )
+remote_execution=ssh
+
+# Verify the authenticity of SAP HANA components ( Default: n )
+verify_signature=n
+
+# Components ( Valid values: all | client | es | ets | lcapps | server | smartda | streaming | rdsync | xs | studio | afl | sca | sop | eml | rme | rtl | trp )
+components={{ _rsp_components }}
+
+# Install Execution Mode ( Default: standard; Valid values: standard | optimized )
+install_execution_mode=standard
+
+# Ignore failing prerequisite checks
+ignore=
+
+# Do not Modify '/etc/sudoers' File ( Default: n )
+skip_modify_sudoers=n
+
+[Server]
+
+# Enable usage of persistent memory ( Default: n )
+use_pmem=n
+
+# Enable the installation or upgrade of the SAP Host Agent ( Default: y )
+install_hostagent=y
+
+# Database Isolation ( Default: low; Valid values: low | high )
+db_isolation=low
+
+# Create initial tenant database ( Default: y )
+create_initial_tenant=y
+
+# Non-standard Shared File System
+checkmnt=
+
+# Installation Path ( Default: /hana/shared )
+sapmnt={{ _rsp_sapmnt }}
+
+# Local Host Name ( Default: x00dhdb00l0b3a )
+hostname={{ _rsp_hostname }}
+
+# Install SSH Key ( Default: y )
+install_ssh_key=y
+
+# Root User Name For Remote Hosts ( Default: root )
+root_user=root
+
+# Root User Password For Remote Hosts
+root_password= {{ main_password }}
+
+# SAP Host Agent User (sapadm) Password
+sapadm_password= {{ main_password }}
+
+# Directory containing a storage configuration
+storage_cfg=
+
+# Listen Interface ( Valid values: global | internal | local )
+listen_interface=
+
+# Internal Network Address
+internal_network=
+
+# SAP HANA System ID
+sid={{ _rsp_sid }}
+
+# Instance Number
+number={{ _rsp_number }}
+
+# Local Host Worker Group ( Default: default )
+workergroup=default
+
+# System Usage ( Default: custom; Valid values: production | test | development | custom )
+system_usage={{ _rsp_system_usage }}
+
+# Instruct the Local Secure Store (LSS) to trust an unsigned SAP HANA Database ( Default: n )
+lss_trust_unsigned_server=n
+
+# Do you want to enable data and log volume encryption? ( Default: n )
+volume_encryption=n
+
+# Location of Data Volumes ( Default: /hana/data/${sid} )
+datapath=/hana/data/${sid}
+
+# Location of Log Volumes ( Default: /hana/log/${sid} )
+logpath=/hana/log/${sid}
+
+# Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
+pmempath=/hana/pmem/${sid}
+
+# Directory containing custom configurations
+custom_cfg=
+
+# SAP HANA Database secure store ( Default: ssfs; Valid values: ssfs | localsecurestore )
+secure_store=ssfs
+
+# Restrict maximum memory allocation?
+restrict_max_mem=
+
+# Maximum Memory Allocation in MB
+max_mem=
+
+# Certificate Host Names
+certificates_hostmap=
+
+# Master Password
+master_password={{ main_password }}
+
+# System Administrator Password
+password=
+
+# System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
+home=/usr/sap/${sid}/home
+
+# System Administrator Login Shell ( Default: /bin/sh )
+shell=/bin/sh
+
+# System Administrator User ID
+userid={{ hdbadm_uid }}
+
+# ID of User Group (sapsys)
+groupid={{ sapsys_gid }}
+
+# Database User (SYSTEM) Password
+system_user_password=
+
+# Restart system after machine reboot? ( Default: n )
+autostart=n
+
+# Enable HANA repository ( Default: y )
+repository=y
+
+# Inter Service Communication Mode ( Valid values: standard | ssl )
+isc_mode=
+
+[Action]
+
+# Action ( Default: exit; Valid values: install | update | extract_components )
+action=install
+
+[AddHosts]
+
+# Auto Initialize Services ( Default: y )
+auto_initialize_services=y
+
+# Additional Hosts
+addhosts=
+
+# Additional Local Host Roles ( Valid values: extended_storage_worker | extended_storage_standby | ets_worker | ets_standby | streaming | xs_worker | xs_standby )
+add_local_roles=
+
+# Automatically assign XS Advanced Runtime roles to the hosts with database roles (y/n) ( Default: y )
+autoadd_xs_roles=y
+
+# Import initial content of XS Advanced Runtime ( Default: y )
+import_xs_content=y
+
+[Client]
+
+# SAP HANA Database Client Installation Path ( Default: ${sapmnt}/${sid}/hdbclient )
+client_path=/hana/shared/${sid}/hdbclient
+
+[Studio]
+
+# SAP HANA Studio Installation Path ( Default: ${sapmnt}/${sid}/hdbstudio )
+studio_path=/hana/shared/${sid}/hdbstudio
+
+# Enables copying of SAP HANA Studio repository ( Default: y )
+studio_repository=y
+
+# Target path to which SAP HANA Studio repository should be copied
+copy_repository=
+
+# Java Runtime ( Default:  )
+vm=
+
+[Reference_Data]
+
+# Installation Path for Address Directories and Reference Data
+reference_data_path=
+
+[XS_Advanced]
+
+# Install XS Advanced in the default tenant database? (y/n) ( Default: n )
+xs_use_default_tenant=n
+
+# XS Advanced App Working Path
+xs_app_working_path=
+
+# Organization Name For Space "SAP" ( Default: orgname )
+org_name=orgname
+
+# XS Advanced Admin User ( Default: XSA_ADMIN )
+org_manager_user=XSA_ADMIN
+
+# XS Advanced Admin User Password
+org_manager_password=
+
+# Customer Space Name ( Default: PROD )
+prod_space_name=PROD
+
+# Routing Mode ( Default: ports; Valid values: ports | hostnames )
+xs_routing_mode=ports
+
+# XS Advanced Domain Name (see SAP Note 2245631)
+xs_domain_name=
+
+# Run Applications in SAP Space with Separate OS User (y/n) ( Default: y )
+xs_sap_space_isolation=y
+
+# Run Applications in Customer Space with Separate OS User (y/n) ( Default: y )
+xs_customer_space_isolation=y
+
+# XS Advanced SAP Space OS User ID
+xs_sap_space_user_id=
+
+# XS Advanced Customer Space OS User ID
+xs_customer_space_user_id=
+
+# XS Advanced Components
+xs_components=
+
+# Do not start the selected XS Advanced components after installation ( Default: none )
+xs_components_nostart=none
+
+# XS Advanced Components Configurations
+xs_components_cfg=
+
+# XS Advanced Certificate
+xs_cert_pem=
+
+# XS Advanced Certificate Key
+xs_cert_key=
+
+# XS Advanced Trust Certificate
+xs_trust_pem=
+
+[lss]
+
+# Installation Path for Local Secure Store ( Default: /lss/shared )
+lss_inst_path=/lss/shared
+
+# Local Secure Store User Password
+lss_user_password=
+
+# Local Secure Store User ID
+lss_userid=
+
+# Local Secure Store User Group ID
+lss_groupid=
+
+# Local Secure Store User Home Directory ( Default: /usr/sap/${sid}/lss/home )
+lss_user_home=/usr/sap/${sid}/lss/home
+
+# Local Secure Store User Login Shell ( Default: /bin/sh )
+lss_user_shell=/bin/sh
+
+# Local Secure Store Auto Backup Password
+lss_backup_password=
+
+[streaming]
+
+# Streaming Cluster Manager Password
+streaming_cluster_manager_password=
+
+# Location of Streaming logstores and runtime information ( Default: /hana/data_streaming/${sid} )
+basepath_streaming=/hana/data_streaming/${sid}
+
+[es]
+
+# Location of Dynamic Tiering Data Volumes ( Default: /hana/data_es/${sid} )
+es_datapath=/hana/data_es/${sid}
+
+# Location of Dynamic Tiering Log Volumes ( Default: /hana/log_es/${sid} )
+es_logpath=/hana/log_es/${sid}
+
+[ets]
+
+# Location of Data Volumes of the Accelerator for SAP ASE ( Default: /hana/data_ase/${sid} )
+ase_datapath=/hana/data_ase/${sid}
+
+# Location of Log Volumes of the Accelerator for SAP ASE ( Default: /hana/log_ase/${sid} )
+ase_logpath=/hana/log_ase/${sid}
+
+# SAP ASE Administrator User ( Default: sa )
+ase_user=sa
+
+# SAP ASE Administrator Password
+ase_user_password=

--- a/SAP/S41909ISS00_v0011ms/templates/HANA_2_00_install.rsp.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/HANA_2_00_install.rsp.j2
@@ -1,0 +1,305 @@
+[General]
+
+# Location of Installation Medium
+component_medium=
+
+# Comma separated list of component directories
+component_dirs=
+
+# Use single master password for all users, created during installation ( Default: n )
+use_master_password=y
+
+# Directory root to search for components
+component_root={{ _rsp_component_root }}
+
+# Skip all SAP Host Agent calls ( Default: n )
+skip_hostagent_calls=n
+
+# Remote Execution ( Default: ssh; Valid values: ssh | saphostagent )
+remote_execution=ssh
+
+# Verify the authenticity of SAP HANA components ( Default: n )
+verify_signature=n
+
+# Components ( Valid values: all | client | es | ets | lcapps | server | smartda | streaming | rdsync | xs | studio | afl | sca | sop | eml | rme | rtl | trp )
+components={{ _rsp_components }}
+
+# Install Execution Mode ( Default: standard; Valid values: standard | optimized )
+install_execution_mode=standard
+
+# Ignore failing prerequisite checks
+ignore=
+
+# Do not Modify '/etc/sudoers' File ( Default: n )
+skip_modify_sudoers=n
+
+[Server]
+
+# Enable usage of persistent memory ( Default: n )
+use_pmem=n
+
+# Enable the installation or upgrade of the SAP Host Agent ( Default: y )
+install_hostagent=y
+
+# Database Isolation ( Default: low; Valid values: low | high )
+db_isolation=low
+
+# Create initial tenant database ( Default: y )
+create_initial_tenant=y
+
+# Non-standard Shared File System
+checkmnt=
+
+# Installation Path ( Default: /hana/shared )
+sapmnt={{ _rsp_sapmnt }}
+
+# Local Host Name ( Default: x00dhdb00l0b3a )
+hostname={{ _rsp_hostname }}
+
+# Install SSH Key ( Default: y )
+install_ssh_key=y
+
+# Root User Name For Remote Hosts ( Default: root )
+root_user=root
+
+# Root User Password For Remote Hosts
+root_password=
+
+# SAP Host Agent User (sapadm) Password
+sapadm_password=
+
+# Directory containing a storage configuration
+storage_cfg=
+
+# Listen Interface ( Valid values: global | internal | local )
+listen_interface=
+
+# Internal Network Address
+internal_network=
+
+# SAP HANA System ID
+sid={{ _rsp_sid }}
+
+# Instance Number
+number={{ _rsp_number }}
+
+# Local Host Worker Group ( Default: default )
+workergroup=default
+
+# System Usage ( Default: custom; Valid values: production | test | development | custom )
+system_usage={{ _rsp_system_usage }}
+
+# Instruct the Local Secure Store (LSS) to trust an unsigned SAP HANA Database ( Default: n )
+lss_trust_unsigned_server=n
+
+# Do you want to enable data and log volume encryption? ( Default: n )
+volume_encryption=n
+
+# Location of Data Volumes ( Default: /hana/data/${sid} )
+datapath=/hana/data/${sid}
+
+# Location of Log Volumes ( Default: /hana/log/${sid} )
+logpath=/hana/log/${sid}
+
+# Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
+pmempath=/hana/pmem/${sid}
+
+# Directory containing custom configurations
+custom_cfg=
+
+# SAP HANA Database secure store ( Default: ssfs; Valid values: ssfs | localsecurestore )
+secure_store=ssfs
+
+# Restrict maximum memory allocation?
+restrict_max_mem=
+
+# Maximum Memory Allocation in MB
+max_mem=
+
+# Certificate Host Names
+certificates_hostmap=
+
+# Master Password
+master_password={{ main_password }}
+
+# System Administrator Password
+password=
+
+# System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
+home=/usr/sap/${sid}/home
+
+# System Administrator Login Shell ( Default: /bin/sh )
+shell=/bin/sh
+
+# System Administrator User ID
+userid={{ hdbadm_uid }}
+
+# ID of User Group (sapsys)
+groupid={{ sapsys_gid }}
+
+# Database User (SYSTEM) Password
+system_user_password=
+
+# Restart system after machine reboot? ( Default: n )
+autostart=n
+
+# Enable HANA repository ( Default: y )
+repository=y
+
+# Inter Service Communication Mode ( Valid values: standard | ssl )
+isc_mode=
+
+[Action]
+
+# Action ( Default: exit; Valid values: install | update | extract_components )
+action=install
+
+[AddHosts]
+
+# Auto Initialize Services ( Default: y )
+auto_initialize_services=y
+
+# Additional Hosts
+addhosts=
+
+# Additional Local Host Roles ( Valid values: extended_storage_worker | extended_storage_standby | ets_worker | ets_standby | streaming | xs_worker | xs_standby )
+add_local_roles=
+
+# Automatically assign XS Advanced Runtime roles to the hosts with database roles (y/n) ( Default: y )
+autoadd_xs_roles=y
+
+# Import initial content of XS Advanced Runtime ( Default: y )
+import_xs_content=y
+
+[Client]
+
+# SAP HANA Database Client Installation Path ( Default: ${sapmnt}/${sid}/hdbclient )
+client_path=/hana/shared/${sid}/hdbclient
+
+[Studio]
+
+# SAP HANA Studio Installation Path ( Default: ${sapmnt}/${sid}/hdbstudio )
+studio_path=/hana/shared/${sid}/hdbstudio
+
+# Enables copying of SAP HANA Studio repository ( Default: y )
+studio_repository=y
+
+# Target path to which SAP HANA Studio repository should be copied
+copy_repository=
+
+# Java Runtime ( Default:  )
+vm=
+
+[Reference_Data]
+
+# Installation Path for Address Directories and Reference Data
+reference_data_path=
+
+[XS_Advanced]
+
+# Install XS Advanced in the default tenant database? (y/n) ( Default: n )
+xs_use_default_tenant=n
+
+# XS Advanced App Working Path
+xs_app_working_path=
+
+# Organization Name For Space "SAP" ( Default: orgname )
+org_name=orgname
+
+# XS Advanced Admin User ( Default: XSA_ADMIN )
+org_manager_user=XSA_ADMIN
+
+# XS Advanced Admin User Password
+org_manager_password=
+
+# Customer Space Name ( Default: PROD )
+prod_space_name=PROD
+
+# Routing Mode ( Default: ports; Valid values: ports | hostnames )
+xs_routing_mode=ports
+
+# XS Advanced Domain Name (see SAP Note 2245631)
+xs_domain_name=
+
+# Run Applications in SAP Space with Separate OS User (y/n) ( Default: y )
+xs_sap_space_isolation=y
+
+# Run Applications in Customer Space with Separate OS User (y/n) ( Default: y )
+xs_customer_space_isolation=y
+
+# XS Advanced SAP Space OS User ID
+xs_sap_space_user_id=
+
+# XS Advanced Customer Space OS User ID
+xs_customer_space_user_id=
+
+# XS Advanced Components
+xs_components=
+
+# Do not start the selected XS Advanced components after installation ( Default: none )
+xs_components_nostart=none
+
+# XS Advanced Components Configurations
+xs_components_cfg=
+
+# XS Advanced Certificate
+xs_cert_pem=
+
+# XS Advanced Certificate Key
+xs_cert_key=
+
+# XS Advanced Trust Certificate
+xs_trust_pem=
+
+[lss]
+
+# Installation Path for Local Secure Store ( Default: /lss/shared )
+lss_inst_path=/lss/shared
+
+# Local Secure Store User Password
+lss_user_password=
+
+# Local Secure Store User ID
+lss_userid=
+
+# Local Secure Store User Group ID
+lss_groupid=
+
+# Local Secure Store User Home Directory ( Default: /usr/sap/${sid}/lss/home )
+lss_user_home=/usr/sap/${sid}/lss/home
+
+# Local Secure Store User Login Shell ( Default: /bin/sh )
+lss_user_shell=/bin/sh
+
+# Local Secure Store Auto Backup Password
+lss_backup_password=
+
+[streaming]
+
+# Streaming Cluster Manager Password
+streaming_cluster_manager_password=
+
+# Location of Streaming logstores and runtime information ( Default: /hana/data_streaming/${sid} )
+basepath_streaming=/hana/data_streaming/${sid}
+
+[es]
+
+# Location of Dynamic Tiering Data Volumes ( Default: /hana/data_es/${sid} )
+es_datapath=/hana/data_es/${sid}
+
+# Location of Dynamic Tiering Log Volumes ( Default: /hana/log_es/${sid} )
+es_logpath=/hana/log_es/${sid}
+
+[ets]
+
+# Location of Data Volumes of the Accelerator for SAP ASE ( Default: /hana/data_ase/${sid} )
+ase_datapath=/hana/data_ase/${sid}
+
+# Location of Log Volumes of the Accelerator for SAP ASE ( Default: /hana/log_ase/${sid} )
+ase_logpath=/hana/log_ase/${sid}
+
+# SAP ASE Administrator User ( Default: sa )
+ase_user=sa
+
+# SAP ASE Administrator Password
+ase_user_password=

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-app-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-app-inifile-param.j2
@@ -1,0 +1,55 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP                                                                                           #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP'                                                                                      #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP'                                                                                    #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAP'                                                                  #
+#                       > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:S4HANA1909.CORE.HDB.PD'                                                         #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+NW_AS.instanceNumber                                                  = {{ app_instance_number }}
+NW_DI_Instance.virtualHostname                                        = {{ sap_appVirtualHostname }}
+
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+HDB_Schema_Check_Dialogs.schemaName                                   = {{ hana_schema }}
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.instanceNumber                                       = {{ hdb_instance_number }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}
+
+# Database hostnames that will be set directly in hdbuserstore without resolving them in HANA. Comma separated. Example (host1,host2)
+HDB_Userstore.doNotResolveHostnames                                   =  {{ virt_do_not_resolve_hostname }}

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-dbload-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-dbload-inifile-param.j2
@@ -1,0 +1,67 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP' #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP' #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                         = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                               = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                               = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                               = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                               = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                               = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid | upper }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+
+
+
+
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPHANADB
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+# Specify if Software Provisioning Manager is to drop the schema if it exists.
+{# HDB_Schema_Check_Dialogs.dropSchema                                   = {{ drop_schema }} #}
+
+NW_HDB_DB.abapSchemaName                                              = SAPHANADB
+NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                                       = {{ hdb_instance_number }}
+NW_HDB_getDBInfo.systemDbPassword                                     = {{ main_password }}
+NW_HDB_getDBInfo.systemPassword                                       = {{ main_password }}
+NW_HDB_getDBInfo.systemid                                             = {{ db_sid | upper }}
+NW_HDB_getDBInfo.usingSSL                                             = true
+
+NW_Recovery_Install_HDB.extractLocation                               = /hana/backup/{{ db_sid | upper }}/HDB{{ hdb_instance_number }}/backup/data/DB_{{ db_sid | upper }}{{ hdb_instance_number }}
+
+NW_Recovery_Install_HDB.extractParallelJobs                           = 24
+NW_Recovery_Install_HDB.sidAdmName                                    = {{ db_sid | lower }}adm
+NW_Recovery_Install_HDB.sidAdmPassword                                = {{ main_password }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-ers-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-ers-inifile-param.j2
@@ -1,0 +1,33 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+###################################################################################################################################
+######################################################################
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP > High-Availability 
+# System > ERS Instance', product id 'NW_ERS:S4HANA1909.CORE.HDB.ABAPHA' #
+#
+###################################################################################################################################
+######################################################################
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+nwUsers.sidadmPassword                                               = {{ main_password }}
+hostAgent.sapAdmPassword                                             = {{ main_password }}
+
+nw_instance_ers.ersInstanceNumber                                    = {{ ers_instance_number }}
+nw_instance_ers.ersVirtualHostname                                   = {{ ers_virtual_hostname }}
+
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+NW_readProfileDir.profileDir                                         = /sapmnt/{{ sap_sid | upper }}/profile
+
+

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-generic-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-generic-inifile-param.j2
@@ -1,0 +1,32 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+#   Creation of user for ERS and SCS issues during HA installation - 14-03-2022
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'Generic Options > SAP HANA Database > Preparations > Operating System Users and Groups', product id 'NW_Users_Create:GENERIC.HDB.PD'                                           #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+NW_Users_Create.dbsid                                                 = {{ sap_sid | upper }}
+
+# Specify whether you are preparing for an SAP sytem based on AS ABAP.
+NW_Users_Create.hasABAP                                               = true
+
+# Specify whether database users are to be installed.
+NW_Users_Create.installDBUsers                                        = false
+
+# SAP system ID
+NW_Users_Create.sid                                                   = {{ sap_sid | upper }}
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+# Password for the 'sapadm' user of the SAP Host Agent
+hostAgent.sapAdmPassword =  {{ main_password }}
+
+
+

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-pas-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-pas-inifile-param.j2
@@ -1,0 +1,80 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP' #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP' #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAP' #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                         = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                               = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                               = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                               = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                               = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                               = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid | upper }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+
+
+HDB_Schema_Check_Dialogs.schemaName                                   = {{ hana_schema }}
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_HDB_DB.abapSchemaName                                              = {{ hana_schema }}
+NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                                       = {{ hdb_instance_number }}
+NW_HDB_getDBInfo.systemDbPassword                                     = {{ main_password }}
+NW_HDB_getDBInfo.systemPassword                                       = {{ main_password }}
+NW_HDB_getDBInfo.systemid                                             = {{ db_sid | upper }}
+NW_HDB_getDBInfo.usingSSL                                             = true
+
+NW_Recovery_Install_HDB.extractLocation                               = /usr/sap/{{ db_sid | upper }}/{{ db_sid | upper }}{{ hdb_instance_number }}/backup/data/DB_HDB
+NW_Recovery_Install_HDB.extractParallelJobs                           = 24
+NW_Recovery_Install_HDB.sidAdmName                                    = {{ db_sid | lower }}adm
+NW_Recovery_Install_HDB.sidAdmPassword                                = {{ main_password }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+NW_CI_Instance.ascsVirtualHostname                                    = {{ sap_scs_hostname }}
+NW_CI_Instance.ciInstanceNumber                                       = {{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciMSPort                                               = 36{{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciVirtualHostname                                      = {{ sap_ciVirtualHostname }}
+NW_CI_Instance.scsVirtualHostname                                     = {{ sap_scs_hostname }}
+
+NW_DDIC_Password.needDDICPasswords                                    = false
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}
+
+NW_WPConfiguration.ciDialogWPNumber                                   = {{ sap_ciDialogWPNumber}}
+NW_WPConfiguration.ciBtcWPNumber                                      = {{ sap_ciBtcWPNumber }}
+
+storageBasedCopy.hdb.instanceNumber                                   = {{ hdb_instance_number }}
+storageBasedCopy.hdb.systemPassword                                   = {{ main_password }}
+
+# Database hostnames that will be set directly in hdbuserstore without resolving them in HANA. Comma separated. Example (host1,host2)
+HDB_Userstore.doNotResolveHostnames                                   =  {{ virt_do_not_resolve_hostname }}

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-scs-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-scs-inifile-param.j2
@@ -1,0 +1,28 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP' #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-scsha-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-scsha-inifile-param.j2
@@ -1,0 +1,27 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+################################################################################################################################################################################################################
+#                                                                                                                                                                                                              #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP > High-Availability System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAPHA' #
+#                                                                                                                                                                                                              #
+################################################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-web-inifile-param.j2
+++ b/SAP/S41909ISS00_v0011ms/templates/S41909ISS00_v0011ms-web-inifile-param.j2
@@ -1,0 +1,44 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP                                                                                           #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP'                                                                                      #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP'                                                                                    #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAP'                                                                  #
+#                       > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:S4HANA1909.CORE.HDB.PD'                                                         #
+#                       > Generic Options > SAP Web Dispatcher > SAP Web Dispatcher (Unicode)', product id 'NW_Webdispatcher:NW750.IND.PD'                                                             #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+NW_GetSidNoProfiles.sid                                               = {{ web_sid| upper }}
+NW_webdispatcher_Instance.backEndSID                                  = {{ sap_sid | upper }}
+
+NW_Webdispatcher_Instance.wdInstanceNumber                            = {{ web_instance_number }}
+NW_webdispatcher_Instance.activateICF                                 = false
+
+NW_webdispatcher_Instance.msHTTPPort                                  = 81{{ sap_ciInstanceNumber }}
+NW_webdispatcher_Instance.msHost                                      = {{ sap_scs_hostname }}
+
+NW_webdispatcher_Instance.rfcHost                                     = {{ sap_scs_hostname }}
+NW_webdispatcher_Instance.wdVirtualHostname                           = {{ sap_webVirtualHostname }}
+
+NW_webdispatcher_Instance.scenarioSize                                = 500
+NW_webdispatcher_Instance.wdHTTPPort                                  = 80{{ web_instance_number }}
+NW_webdispatcher_Instance.wdHTTPSPort                                 = 443{{ web_instance_number }}
+
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}

--- a/SAP/S42020ISS00_v0003ms/S42020ISS00_v0003ms.yaml
+++ b/SAP/S42020ISS00_v0003ms/S42020ISS00_v0003ms.yaml
@@ -1,0 +1,1016 @@
+---
+
+    name:                              "SAP S/4HANA 2020 ISS 00"
+    filename:                          "S42020ISS00_v0003ms"
+    target:                            'S/4 HANA 2020 ISS 00'
+    version:                           3
+    platform:                          'HANA'
+    InstanceType:                      "ABAP"
+
+    defaults:
+      target_location:             "{{ target_media_location }}/download_basket"
+
+    product_ids:
+      scs:         NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAP
+      scs_ha:      NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAPHA
+      dbl:         NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAP
+      pas:         NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP
+      pas_ha:      NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAPHA
+      app:         NW_DI:S4HANA2020.CORE.HDB.PD
+      app_ha:      NW_DI:S4HANA2020.CORE.HDB.ABAPHA
+      web:
+      ers:         NW_ERS:S4HANA2020.CORE.HDB.ABAP
+      ers_ha:      NW_ERS:S4HANA2020.CORE.HDB.ABAPHA
+      generic:     NW_Users_Create:GENERIC.HDB.PD
+
+    materials:
+      dependencies:
+        - name:     HANA_2_00_067_v0006ms
+        - name:     SWPM20SP16_latest
+        - name:     SUM20SP18_latest
+
+      media:
+        # SAPCAR 7.XX
+
+        - name:         "SAPCAR 7.22; OS: Linux on x86_64 64bit"
+          archive:      SAPCAR_1115-70006178.EXE
+          checksum:     765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5
+          filename:     SAPCAR
+          permissions:  '0755'
+          url:          https://softwaredownloads.sap.com/file/0020000000098642022
+
+        # kernel components
+        - name: "Kernel Part I (785)"
+          archive: SAPEXE_100-80005374.SAR
+          checksum: 31002d86645b5ed2f03a5ee5508083939b0e219116e2a7a126c3930beb642888
+          url: https://softwaredownloads.sap.com/file/0020000000249732022
+          path: download_basket
+
+        - name: "Kernel Part II (785)"
+          archive: SAPEXEDB_100-80005373.SAR
+          checksum: 05a16e9ba5c6c882972fc37ee09c675ca5c06e02d56ea3cd36e39aa0bb809b37
+          url: https://softwaredownloads.sap.com/file/0020000000250002022
+          path: download_basket
+
+        - name: "SAP HOST AGENT 7.22 SP57"
+          archive: SAPHOSTAGENT57_57-80004822.SAR
+          checksum: cb016253932342c0dde6c2a89edfcf5a7c38af0ed3f72b841eb5249a88467648
+          url: https://softwaredownloads.sap.com/file/0020000000983272022
+          path: download_basket
+
+        - name: "Installation for SAP IGS integrated in SAP Kernel"
+          archive: igsexe_1-70005417.sar
+          checksum: 31e299129fa931c05fb93fcc53f89b568629cb199bca027ac3ee9b7986025629
+          url: https://softwaredownloads.sap.com/file/0020000000535042021
+          path: download_basket
+
+        - name: "SAP IGS Fonts and Textures"
+          archive: igshelper_17-10010245.sar
+          checksum: bc405afc4f8221aa1a10a8bc448f8afd9e4e00111100c5544097240c57c99732
+          url: https://softwaredownloads.sap.com/file/0020000000703122018
+          path: download_basket
+
+        # db export components
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_1.zip"
+          archive: S4CORE105_INST_EXPORT_1.zip
+          checksum: bf8ea8d901a9be19b008b20025d9120360c53277e8bc08b31ca7ff837718eadc
+          url: https://softwaredownloads.sap.com/file/0030000001666752020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_2.zip"
+          archive: S4CORE105_INST_EXPORT_2.zip
+          checksum: 8443085add99ad782c6d1be039ceeac1865a6a78fe448835f8af5ff06c62f116
+          url: https://softwaredownloads.sap.com/file/0030000001666922020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_3.zip"
+          archive: S4CORE105_INST_EXPORT_3.zip
+          checksum: b3291c94a1981097f6a24936d99a1c5002a319acffcb0be806e54a4359075274
+          url: https://softwaredownloads.sap.com/file/0030000001667002020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_4.zip"
+          archive: S4CORE105_INST_EXPORT_4.zip
+          checksum: 56412f68d17920c8cffb6d1af0d39a60c73b8d47a2b572bed38eafd3e31956b1
+          url: https://softwaredownloads.sap.com/file/0030000001667012020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_5.zip"
+          archive: S4CORE105_INST_EXPORT_5.zip
+          checksum: 1ec1bbac65617081ab4ca20976d99d4824a2e9cd8371743059adc4add01d4180
+          url: https://softwaredownloads.sap.com/file/0030000001667022020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_6.zip"
+          archive: S4CORE105_INST_EXPORT_6.zip
+          checksum: 2186941d7584d21e718fe2ab2e9df92221d4322751d317dabc9131f37c7c2a2f
+          url: https://softwaredownloads.sap.com/file/0030000001667032020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_7.zip"
+          archive: S4CORE105_INST_EXPORT_7.zip
+          checksum: a569ca20838ad888ec881024840c4a31db5c76ae2dbb4ba31f6e2f1ac9cd18a8
+          url: https://softwaredownloads.sap.com/file/0030000001667052020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_8.zip"
+          archive: S4CORE105_INST_EXPORT_8.zip
+          checksum: b94fab3ede5a111b1709af65352c835d531407fb09e12a146fdc97a61786b592
+          url: https://softwaredownloads.sap.com/file/0030000001667062020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_9.zip"
+          archive: S4CORE105_INST_EXPORT_9.zip
+          checksum: 14c2982a43f9f61cd2446fff6474e0368bcc27799883c6a06768783d06698322
+          url: https://softwaredownloads.sap.com/file/0030000001667072020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_10.zip"
+          archive: S4CORE105_INST_EXPORT_10.zip
+          checksum: 53223fe52caae836b0a63a673e9d8f5e9a3b767d1139c9380a56030a652a13fa
+          url: https://softwaredownloads.sap.com/file/0030000001666762020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_11.zip"
+          archive: S4CORE105_INST_EXPORT_11.zip
+          checksum: 41a07b3a213ddf3a2ce2ebcdf971e325ee2c9c725495c0908bd5772f43efd5d9
+          url: https://softwaredownloads.sap.com/file/0030000001666772020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_12.zip"
+          archive: S4CORE105_INST_EXPORT_12.zip
+          checksum: c8dc600b858ffa32d99e4e1aa18b632674c55e2cf1d2d38e88ac968b78ead2ab
+          url: https://softwaredownloads.sap.com/file/0030000001666782020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_13.zip"
+          archive: S4CORE105_INST_EXPORT_13.zip
+          checksum: 005012e0736bd8ee7f5862c23d5be3d9172d7a7efac6c50553561806ecc8442b
+          url: https://softwaredownloads.sap.com/file/0030000001666802020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_14.zip"
+          archive: S4CORE105_INST_EXPORT_14.zip
+          checksum: d1b012b1694c55aee5b1e158d11d9d7831742affda319749bbd71ebc5db16c04
+          url: https://softwaredownloads.sap.com/file/0030000001666842020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_15.zip"
+          archive: S4CORE105_INST_EXPORT_15.zip
+          checksum: a9925856644cec2404956e17218dc0d7555cbcb8c402d007faa7c0beac1b0f8a
+          url: https://softwaredownloads.sap.com/file/0030000001666862020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_16.zip"
+          archive: S4CORE105_INST_EXPORT_16.zip
+          checksum: 473282155d7e5a9d86312d4f95b1df350d952b32ffd4494b29b1228746484d02
+          url: https://softwaredownloads.sap.com/file/0030000001666872020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_17.zip"
+          archive: S4CORE105_INST_EXPORT_17.zip
+          checksum: b00799a132ae3b6f0798791c0a8389090ee6fe64895898b2f9bf37a7881e1836
+          url: https://softwaredownloads.sap.com/file/0030000001666882020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_18.zip"
+          archive: S4CORE105_INST_EXPORT_18.zip
+          checksum: 23552a7bf21e0b92765e9778b6f081e11680a58c4d7d63c8598ee95d5879a9d1
+          url: https://softwaredownloads.sap.com/file/0030000001666892020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_19.zip"
+          archive: S4CORE105_INST_EXPORT_19.zip
+          checksum: 9d60e53217e0566b05fe06dc7dfde016d2f8f259c73fef6064b5a4f1772a24f8
+          url: https://softwaredownloads.sap.com/file/0030000001666912020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_20.zip"
+          archive: S4CORE105_INST_EXPORT_20.zip
+          checksum: fc6eae3d201d3b839deab2f7196976b40408bd24bf5ea85183235790e483e8cc
+          url: https://softwaredownloads.sap.com/file/0030000001666932020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_21.zip"
+          archive: S4CORE105_INST_EXPORT_21.zip
+          checksum: f76a740da5218d8445ef028b501fff8486b4eb315367f70dba93940f4bfdf6e5
+          url: https://softwaredownloads.sap.com/file/0030000001666942020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_22.zip"
+          archive: S4CORE105_INST_EXPORT_22.zip
+          checksum: f5b2af2bca509a8cfa1738e23490ef646a657abffd7c94863abd445057f60ad8
+          url: https://softwaredownloads.sap.com/file/0030000001666952020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_23.zip"
+          archive: S4CORE105_INST_EXPORT_23.zip
+          checksum: db4f4b1e52665fbf9b8a98ee36c3f702e3aaec3cd9278f5ad6b7d777693a7810
+          url: https://softwaredownloads.sap.com/file/0030000001666982020
+          path: download_basket
+
+        - name: "File on DVD - S4CORE105_INST_EXPORT_24.zip"
+          archive: S4CORE105_INST_EXPORT_24.zip
+          checksum: 7d78b729a8c5ff021e943a2decfb4c8c047458b1848939e50edf37c6915fc46b
+          url: https://softwaredownloads.sap.com/file/0030000001666992020
+          path: download_basket
+
+        # Language packs, only add the mandatory ones i.e. German and English
+        - name: "File on DVD - S4HANAOP105_ERP_LANG_DE.SAR"
+          archive: S4HANAOP105_ERP_LANG_DE.SAR
+          checksum: 4955bd2b211c68f5f6c6de5d9e36b3a2b24c47b4a5aff8912d75fb9339b60b39
+          url: https://softwaredownloads.sap.com/file/0030000001665632020
+          path: download_basket
+
+        - name: "File on DVD - S4HANAOP105_ERP_LANG_EN.SAR"
+          archive: S4HANAOP105_ERP_LANG_EN.SAR
+          checksum: 5465d21fca61b06d32371103e12ba4216210ccc1727e95fba9eb9aef6aa0f29b
+          url: https://softwaredownloads.sap.com/file/0030000001665642020
+          path: download_basket
+
+        # other components
+
+        - name: "Attribute Change Package 18 for EA-HR 608"
+          archive: EA-HR608.SAR
+          checksum: 5d709769878a6f53ca658ada1fe272b1d776619cc6f29042217786362659d0bc
+          url: https://softwaredownloads.sap.com/file/0010000000059642016
+          download: false
+
+        - name: "Attribute Change Package 28 for GBX01HR5 605"
+          archive: GBX01HR5605.SAR
+          checksum: 9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
+          url: https://softwaredownloads.sap.com/file/0010000000033172015
+          download: false
+
+        - name: "Attribute Change Package 19 for GBX01HR 600"
+          archive: GBX01HR600.SAR
+          checksum: 92e966f40681b11bad6c7bcd068387fdcf196974592aca6e0fae01267ff8a75e
+          url: https://softwaredownloads.sap.com/file/0010000000029982015
+          download: false
+
+        - name: "S4CEXT 105: SP 0001"
+          archive: K-10501INS4CEXT.SAR
+          checksum: b472792d9b2fb2b53749ce0822b0d3a59fde36821b7910dc74bd17cd22e72c01
+          url: https://softwaredownloads.sap.com/file/0010000000025122021
+          download: false
+
+        - name: "S4CORE 105: SP 0001"
+          archive: K-10501INS4CORE.SAR
+          checksum: 55d1915b8d3a33cd9d65fe2a766c28ef3a8c8479b8a3ffcd470ac9389628cc77
+          url: https://softwaredownloads.sap.com/file/0010000000077602021
+          download: false
+
+        - name: "S4COREOP 105: SP 0001"
+          archive: K-10501INS4COREOP.SAR
+          checksum: 03aaf041215edfab2459364fdd21ec32be3cd5c727ed5010eda8fd8be0eb33f0
+          url: https://softwaredownloads.sap.com/file/0010000000025142021
+          download: false
+
+        - name: "S4DEPREC 105: SP 0001"
+          archive: K-10501INS4DEPREC.SAR
+          checksum: f3ae490937bdef9e3acc66840a3516483f48287a9e95bd545acbee70090c5a55
+          url: https://softwaredownloads.sap.com/file/0010000000595472021
+          download: false
+
+        - name: "S4FND 105: SP 0001"
+          archive: K-10501INS4FND.SAR
+          checksum: dec006c44317bb236ebefabdae72dc062c48cc26bf2bf7afe7afed6cbc404674
+          url: https://softwaredownloads.sap.com/file/0010000000025152021
+          download: false
+
+        - name: "S4CEXT 105: SP 0002"
+          archive: K-10502INS4CEXT.SAR
+          checksum: 6e5fa3979ddc125c1c03ccbf65c5f93012ce1265ff855d4d895872b888614e70
+          url: https://softwaredownloads.sap.com/file/0010000000595482021
+          download: false
+
+        - name: "S4CORE 105: SP 0002"
+          archive: K-10502INS4CORE.SAR
+          checksum: f3156dde62101ded74f2457feafff2e25202c9c9d3d23740cfd163224a8fcdce
+          url: https://softwaredownloads.sap.com/file/0010000000596032021
+          download: false
+
+        - name: "S4COREOP 105: SP 0002"
+          archive: K-10502INS4COREOP.SAR
+          checksum: 0c6a1697c05d1d61d002ddaaeaae4e1352a0cbb37bb0a1b882d0faf9a439a2cb
+          url: https://softwaredownloads.sap.com/file/0010000000595492021
+          download: false
+
+        - name: "S4DEPREC 105: SP 0002"
+          archive: K-10502INS4DEPREC.SAR
+          checksum: c1649f0fd111c4e0bde0375943f3fb8b5f64af1722f474b1a0cd87de67aba2e1
+          url: https://softwaredownloads.sap.com/file/0010000001433082021
+          download: false
+
+        - name: "S4FND 105: SP 0002"
+          archive: K-10502INS4FND.SAR
+          checksum: bb3a888bd142ec9981d2432adf26f97f4912ba9d2d7485b6b3598027cf623ae5
+          url: https://softwaredownloads.sap.com/file/0010000000595502021
+          download: false
+
+        - name: "S4CEXT 105: SP 0003"
+          archive: K-10503INS4CEXT.SAR
+          checksum: a9a2e74f45b87f211bcbb7a579a0cee4209bd95b6afb515c3a85b1c9a365c1f5
+          url: https://softwaredownloads.sap.com/file/0010000001433092021
+          download: false
+
+        - name: "S4CORE 105: SP 0003"
+          archive: K-10503INS4CORE.SAR
+          checksum: 43d5b2aea853e5fd1da1e8298b9d97a28085b12b5cf3722d90ea6de2e0045286
+          url: https://softwaredownloads.sap.com/file/0010000001431422021
+          download: false
+
+        - name: "S4COREOP 105: SP 0003"
+          archive: K-10503INS4COREOP.SAR
+          checksum: e6b0947d1486e959cbd5af90a338809276b7f226c486db1e80453785168c56d8
+          url: https://softwaredownloads.sap.com/file/0010000001433102021
+          download: false
+
+        - name: "S4FND 105: SP 0003"
+          archive: K-10503INS4FND.SAR
+          checksum: c2f15200929f18af1e28a3c1577107f6efa4f322da78a3621f2387fa2a33729c
+          url: https://softwaredownloads.sap.com/file/0010000001433122021
+          download: false
+
+        - name: "S4CRM 205: SP 0001"
+          archive: K-20501INS4CRM.SAR
+          checksum: b136ca4b7cc626f162f772f2866ae0cd7d6953190feb5aa64bc5ba6514a00b0a
+          url: https://softwaredownloads.sap.com/file/0010000000025162021
+          download: false
+
+        - name: "S4CRM 205: SP 0002"
+          archive: K-20502INS4CRM.SAR
+          checksum: 88f62010f2608a49091df90bc96e134cd9d1a27093992dce98b44be4ff4c632b
+          url: https://softwaredownloads.sap.com/file/0010000000595512021
+          download: false
+
+        - name: "S4CRM 205: SP 0003"
+          archive: K-20503INS4CRM.SAR
+          checksum: 7fbbd062ae6574d3447ecd137e22723f725fde0b5fa82ad29ce997e80d4442e6
+          url: https://softwaredownloads.sap.com/file/0010000001433142021
+          download: false
+
+        - name: "UIBAS001 600: SP 0001"
+          archive: K-60001INUIBAS001.SAR
+          checksum: a1ecf5288e6bbe5a7b00dbd096ca42fac45d49da0f391a9f6f391132b11997b2
+          url: https://softwaredownloads.sap.com/file/0010000000013032021
+          download: false
+
+        - name: "UIS4HOP1 600: SP 0001"
+          archive: K-60001INUIS4HOP1.SAR
+          checksum: 20cc69af6e82b25bd55a73d972a90fd291cac39172d293db9a41aca3ecfea74a
+          url: https://softwaredownloads.sap.com/file/0010000000003012021
+          download: false
+
+        - name: "UIS4HOP1 600: SP 0002"
+          archive: K-60002INUIS4HOP1.SAR
+          checksum: 73a4e2e04864b08b643f1068250c4b43995a38f6a169fb8899d66c0c2200e455
+          url: https://softwaredownloads.sap.com/file/0010000000578272021
+          download: false
+
+        - name: "UIS4HOP1 600: SP 0003"
+          archive: K-60003INUIS4HOP1.SAR
+          checksum: 3aea929578e27d009ff491379c120c4a2319511c408a3f7b2bb0487967b15c95
+          url: https://softwaredownloads.sap.com/file/0010000001550222021
+          download: false
+
+        - name: "GBX01HR 600: SP 0018"
+          archive: K-60018INGBX01HR.SAR
+          checksum: 35d8da893b4b6c29a0f4fadc26a0aeceddf223ab5c94e63eda47d462215d56fd
+          url: https://softwaredownloads.sap.com/file/0010000001530032020
+          download: false
+
+        - name: "GBX01HR 600: SP 0019"
+          archive: K-60019INGBX01HR.SAR
+          checksum: d8200111bbb645c3d465ab19a8b13806c5f96b13ba851d1a601e11d0b2615d66
+          url: https://softwaredownloads.sap.com/file/0010000002051952020
+          download: false
+
+        - name: "UIBAS001 600: Add-On Installation"
+          archive: K-600AGINUIBAS001.SAR
+          checksum: b7441f9f3916861edee5fce48ea0d62f73220e2c457dddedc75385c3d837f501
+          url: https://softwaredownloads.sap.com/file/0010000000638612020
+          download: false
+
+        - name: "UIS4HOP1 600: Add-On Installation"
+          archive: K-600AGINUIS4HOP1.SAR
+          checksum: afe62f81d8ff9f0d760a8ea35ab709d9bbec121bd8949125880df8ce9b199964
+          url: https://softwaredownloads.sap.com/file/0010000001013212020
+          download: false
+
+        - name: "GBX01HR5 605: SP 0015"
+          archive: K-60515INGBX01HR5.SAR
+          checksum: 3cc9d632d4bb92adecf617482b92f742ed944a742484bd3ce90fece2edd44a64
+          url: https://softwaredownloads.sap.com/file/0010000001521702020
+          download: false
+
+        - name: "GBX01HR5 605: SP 0016"
+          archive: K-60516INGBX01HR5.SAR
+          checksum: 955ef4c5cad3ffc43403761aa9e7e70c5fa1c8bcab53742972baddb0f236645e
+          url: https://softwaredownloads.sap.com/file/0010000002052532020
+          download: false
+
+        - name: "GBX01HR5 605: SP 0017"
+          archive: K-60517INGBX01HR5.SAR
+          checksum: 69f58a9703011124caa0d6e7a780ada13851d1586aece99a153d3d49aead5287
+          url: https://softwaredownloads.sap.com/file/0010000000258892021
+          download: false
+
+        - name: "GBX01HR5 605: SP 0018"
+          archive: K-60518INGBX01HR5.SAR
+          checksum: 47b38841123edb3445a634753ff5df2d0b6a668545b47e3bf82b4c01390394b5
+          url: https://softwaredownloads.sap.com/file/0010000000770752021
+          download: false
+
+        - name: "GBX01HR5 605: SP 0019"
+          archive: K-60519INGBX01HR5.SAR
+          checksum: 94a68bbc8fb6d6bc220788757e411603741447e02bb2a420ab24c40cc8315e30
+          url: https://softwaredownloads.sap.com/file/0010000001243172021
+          download: false
+
+        - name: "EA-HR 608: SP 0083"
+          archive: K-60883INEAHR.SAR
+          checksum: 2e0fb0fa90bca1c152edf6669f7d7118886acffb782506aa45c5a63b6a04fd34
+          url: https://softwaredownloads.sap.com/file/0010000001324782020
+          download: false
+
+        - name: "EA-HR 608: SP 0084"
+          archive: K-60884INEAHR.SAR
+          checksum: 76561e41400cb15c2e0a11aab41b4e15be0362e78bf322a327947caa166bedb0
+          url: https://softwaredownloads.sap.com/file/0010000001507772020
+          download: false
+
+        - name: "EA-HR 608: SP 0085"
+          archive: K-60885INEAHR.SAR
+          checksum: 545705bb821b427722984c79491ef7906c88e949630f7c6fcb480bf57edde23d
+          url: https://softwaredownloads.sap.com/file/0010000001676532020
+          download: false
+
+        - name: "EA-HR 608: SP 0086"
+          archive: K-60886INEAHR.SAR
+          checksum: ec6c3e0b1b1a8e022b6d65f03f903193b062a0d2e0b2c2186143c9fb10497f1a
+          url: https://softwaredownloads.sap.com/file/0010000001888832020
+          download: false
+
+        - name: "EA-HR 608: SP 0087"
+          archive: K-60887INEAHR.SAR
+          checksum: d14b3f2c6a70ad1a9441def5c88b70d8c743ae3dc7e272fe15d8aea3afa97380
+          url: https://softwaredownloads.sap.com/file/0010000002067062020
+          download: false
+
+        - name: "EA-HR 608: SP 0088"
+          archive: K-60888INEAHR.SAR
+          checksum: ec3fed017ee73aaa178e0717be3603556853ca5ac5e15ea96ad506bad1e0aa69
+          url: https://softwaredownloads.sap.com/file/0010000002135512020
+          download: false
+
+        - name: "EA-HR 608: SP 0089"
+          archive: K-60889INEAHR.SAR
+          checksum: 9099059568d9b1f0622485b48b35f5110192b780a866cfff1f966ab8ca2ae93b
+          url: https://softwaredownloads.sap.com/file/0010000000065512021
+          download: false
+
+        - name: "EA-HR 608: SP 0090"
+          archive: K-60890INEAHR.SAR
+          checksum: a554c981928baad912c3289acd2cf3aeea1a5d641a8519f985eef251dcbb2e88
+          url: https://softwaredownloads.sap.com/file/0010000000184582021
+          download: false
+
+        - name: "EA-HR 608: SP 0091"
+          archive: K-60891INEAHR.SAR
+          checksum: f331cc3e80820059c4468550c22480ac0b3905c043b5b8ed8d673d38143b56b0
+          url: https://softwaredownloads.sap.com/file/0010000000340882021
+          download: false
+
+        - name: "EA-HR 608: SP 0092"
+          archive: K-60892INEAHR.SAR
+          checksum: 11961732aaed242e474da05d6ae2efb7350e2437cc660f90674dc9f2dc985d67
+          url: https://softwaredownloads.sap.com/file/0010000000545472021
+          download: false
+
+        - name: "EA-HR 608: SP 0093"
+          archive: K-60893INEAHR.SAR
+          checksum: f6d219a99c407c7ca209a985a2780f53f6d50f7638798f0771174be29e291f02
+          url: https://softwaredownloads.sap.com/file/0010000000683052021
+          download: false
+
+        - name: "EA-HR 608: SP 0094"
+          archive: K-60894INEAHR.SAR
+          checksum: 763c0352594f7d3682a02ad8704d3d846d4a955f1831205b25d2042619991a71
+          url: https://softwaredownloads.sap.com/file/0010000000817232021
+          download: false
+
+        - name: "EA-HR 608: SP 0095"
+          archive: K-60895INEAHR.SAR
+          checksum: 78a36f5ea8843d2209240f808e386c70efbd1fd26007e86f7c6d86e11d8b7daa
+          url: https://softwaredownloads.sap.com/file/0010000000999642021
+          download: false
+
+        - name: "EA-HR 608: SP 0096"
+          archive: K-60896INEAHR.SAR
+          checksum: 696c04b9b76c0abf33891e7346a095072b5d9a3a17b96b9e829331c3d5d65c12
+          url: https://softwaredownloads.sap.com/file/0010000001143012021
+          download: false
+
+        - name: "EA-HR 608: SP 0097"
+          archive: K-60897INEAHR.SAR
+          checksum: 2f1c568001a54b360c1fcd4b8192cc7085740cb1207d8981e78bbbcdd4934c0b
+          url: https://softwaredownloads.sap.com/file/0010000001272012021
+          download: false
+
+        - name: "ST-PI 740: SP 0014"
+          archive: K-74014INSTPI.SAR
+          checksum: f1a9058c623360d576469c51a74e5e649b7055bcac200c5b0f8165801a189048
+          url: https://softwaredownloads.sap.com/file/0010000001984822020
+          download: false
+
+        - name: "ST-PI 740: SP 0015"
+          archive: K-74015INSTPI.SAR
+          checksum: d877446c5d3c41af8d10dda15b11a61d9ac36b795fe6ace9b7f99654576278af
+          url: https://softwaredownloads.sap.com/file/0010000000853222021
+          download: false
+
+        - name: "ST-PI 740: SP 0016"
+          archive: K-74016INSTPI.SAR
+          checksum: 0d5a3c74f813dad48345023c7acd146dc9ef84c121c6d854292cb534006c40a5
+          url: https://softwaredownloads.sap.com/file/0010000001454472021
+          download: false
+
+        - name: "ST-PI 740: SP 0017"
+          archive: K-74017INSTPI.SAR
+          checksum: 31b7567ef9510cb1c7dc1434fd55a27531342e4ed8b9b90bc9ca8bd5393b5a64
+          url: https://softwaredownloads.sap.com/file/0010000000096822022
+          download: false
+
+        - name: "ST-PI 740: SP 0018"
+          archive: K-74018INSTPI.SAR
+          checksum: 335237b94424f625f65fb599c4c48771daa64d37e773fa8b1111131e73ad0112
+          url: https://softwaredownloads.sap.com/file/0010000000509342022
+          download: false
+
+        - name: "ST-PI 740: SP 0019"
+          archive: K-74019INSTPI.SAR
+          checksum: 4f46e84736c31cea16c2095b6337347a7e9707982ed969a434ba44350842abd2
+          url: https://softwaredownloads.sap.com/file/0010000000788312022
+          download: false
+
+        - name: "SAP_BASIS 755: SP 0001"
+          archive: K-75501INSAPBASIS.SAR
+          checksum: 50604b03747cf8bd6051ed7b45f7f874b5a17771645322215d3aeee7b26cc5a8
+          url: https://softwaredownloads.sap.com/file/0010000000042962021
+          download: false
+
+        - name: "SAP_BW 755: SP 0001"
+          archive: K-75501INSAPBW.SAR
+          checksum: 3f97975cd9934d3f3769efc06aa4a197b421750cf830a586c25a6d87ea73c2f5
+          url: https://softwaredownloads.sap.com/file/0010000002112932020
+          download: false
+
+        - name: "SAP_GWFND 755: SP 0001"
+          archive: K-75501INSAPGWFND.SAR
+          checksum: 1cb98c5b3085d0ed6593a0f78d5e3b1970a4c6e741aa2ce6448538f9e846b58c
+          url: https://softwaredownloads.sap.com/file/0010000002112942020
+          download: false
+
+        - name: "SAP_UI 755: SP 0001"
+          archive: K-75501INSAPUI.SAR
+          checksum: 738bc98319eea3dc1a4abb10d76526aeb7349ca6d9765a04f020d365ce9a7ad8
+          url: https://softwaredownloads.sap.com/file/0010000001645292020
+          download: false
+
+        - name: "SAP_BASIS 755: SP 0002"
+          archive: K-75502INSAPBASIS.SAR
+          checksum: a419099e2b4c8469cbceeaf9f756595a1d8aedb21ac5a02500caa4c6f25fdcf4
+          url: https://softwaredownloads.sap.com/file/0010000000566632021
+          download: false
+
+        - name: "SAP_BW 755: SP 0002"
+          archive: K-75502INSAPBW.SAR
+          checksum: 03d7f4a4f4509844e57954a485ac1b9da72caf2329e7e99d5142e5d9685a7575
+          url: https://softwaredownloads.sap.com/file/0010000000578322021
+          download: false
+
+        - name: "SAP_GWFND 755: SP 0002"
+          archive: K-75502INSAPGWFND.SAR
+          checksum: 794d6f89a675f9c491593d38b2e800d27076f27fd09765c599eead6cb6eedd14
+          url: https://softwaredownloads.sap.com/file/0010000000462562021
+          download: false
+
+        - name: "SAP_UI 755: SP 0002"
+          archive: K-75502INSAPUI.SAR
+          checksum: a07a5cc7d959e7b99adc1ae698c4c259f1f8604d4cb9afa602fd3fe6bceaab77
+          url: https://softwaredownloads.sap.com/file/0010000002112912020
+          download: false
+
+        - name: "SAP_BASIS 755: SP 0003"
+          archive: K-75503INSAPBASIS.SAR
+          checksum: ba7c233309e9e5392af4266dfbcd60ebc859d675eb6ae76b3b90868fb3e0b41b
+          url: https://softwaredownloads.sap.com/file/0010000001314422021
+          download: false
+
+        - name: "SAP_BW 755: SP 0003"
+          archive: K-75503INSAPBW.SAR
+          checksum: cf6687bd8462e82462c399a377070b105892649e93f73d91a91b9dfa60ba7098
+          url: https://softwaredownloads.sap.com/file/0010000001314452021
+          download: false
+
+        - name: "SAP_GWFND 755: SP 0003"
+          archive: K-75503INSAPGWFND.SAR
+          checksum: 91e6d88a5b3b6fe493fe889000d0aa025631ac874b265b6d99aabdd5901ae2bc
+          url: https://softwaredownloads.sap.com/file/0010000001314462021
+          download: false
+
+        - name: "SAP_UI 755: SP 0003"
+          archive: K-75503INSAPUI.SAR
+          checksum: d2a3f0cba87f1ae7abd0bcb77ae34e88b9d05669e1f906e47f156ef7332298c3
+          url: https://softwaredownloads.sap.com/file/0010000000462572021
+          download: false
+
+        - name: "SAP_GWFND 755: SP 0004"
+          archive: K-75504INSAPGWFND.SAR
+          checksum: 33b4b5afb25840f54de8384b36f86a299b05e646fde71157f81553d5a22d71e7
+          url: https://softwaredownloads.sap.com/file/0010000000324402022
+          download: false
+
+        - name: "SAP_UI 755: SP 0004"
+          archive: K-75504INSAPUI.SAR
+          checksum: ea086c862966c65d0f6f4a9c60ee6a426ef3981fbb391a74ca235fdef18ff5fb
+          url: https://softwaredownloads.sap.com/file/0010000000869082021
+          download: false
+
+        - name: "SAP_UI 755: SP 0005"
+          archive: K-75505INSAPUI.SAR
+          checksum: b7b93b2fd624c31bb764af4eab2f6fa6013373ea3b4057aeebe19cc8614aff6f
+          url: https://softwaredownloads.sap.com/file/0010000001314472021
+          download: false
+
+        - name: "SAP_ABA 75F: SP 0001"
+          archive: K-75F01INSAPABA.SAR
+          checksum: a0f75746d053e0bfa0283a90d59397667d7df05e06ae3e628752828765e2a45f
+          url: https://softwaredownloads.sap.com/file/0010000002112962020
+          download: false
+
+        - name: "SAP_ABA 75F: SP 0002"
+          archive: K-75F02INSAPABA.SAR
+          checksum: 6ec2f6b9d2c8649320fdff2a109e6e10e6981893dd7092ce31fb0a4f7dba16e1
+          url: https://softwaredownloads.sap.com/file/0010000000462582021
+          download: false
+
+        - name: "SAP_ABA 75F: SP 0003"
+          archive: K-75F03INSAPABA.SAR
+          checksum: 7083f45070f6fad52552cfd149f3daaaabcbe67d8e304f0ec68d6a2f2b71f6ce
+          url: https://softwaredownloads.sap.com/file/0010000001314502021
+          download: false
+
+        - name: "UIAPFI70 800: SP 0001"
+          archive: K-80001INUIAPFI70.SAR
+          checksum: 9b1dbd775d9606a6cd154915bf5310146066b66d2b5ac5505481b6fa5572e65a
+          url: https://softwaredownloads.sap.com/file/0010000000003002021
+          download: false
+
+        - name: "UIAPFI70 800: SP 0002"
+          archive: K-80002INUIAPFI70.SAR
+          checksum: 3cbdc82e127d37d45aef2e3a65773f313a1e374c3731af50c47df39bb1c8eaf9
+          url: https://softwaredownloads.sap.com/file/0010000000578282021
+          download: false
+
+        - name: "UIAPFI70 800: SP 0003"
+          archive: K-80003INUIAPFI70.SAR
+          checksum: c554d9108572f08ed19e06c9c65f2067be941e85b791c000591c13d6989ad41e
+          url: https://softwaredownloads.sap.com/file/0010000001550202021
+          download: false
+
+        - name: "UIAPFI70 800: Add-On Installation"
+          archive: K-800AGINUIAPFI70.SAR
+          checksum: ddceff148d92a6d6fc3d952d79de797b3db4624eb8b0e6adc37ebb9bfd0feb13
+          url: https://softwaredownloads.sap.com/file/0010000001013272020
+          download: false
+
+        - name: "EA-DFPS 805: SP 0001"
+          archive: K-80501INEADFPS.SAR
+          checksum: 67d4a04f0f36a2984ad80eb9762d4810dd7c44e6302347bf25c0ba261efd1d4c
+          url: https://softwaredownloads.sap.com/file/0010000000025172021
+          download: false
+
+        - name: "EA-PS 805: SP 0001"
+          archive: K-80501INEAPS.SAR
+          checksum: d4967a7b06c33f07a2bb445944a31c0e6495368a8e35c6270fe101753f4dd592
+          url: https://softwaredownloads.sap.com/file/0010000000025182021
+          download: false
+
+        - name: "FI-CAX 805: SP 0001"
+          archive: K-80501INFICAX.SAR
+          checksum: 7aa61cc1c94fc6b9266db5da93e7f909c56a4817a97c5021c1580eca2d72c187
+          url: https://softwaredownloads.sap.com/file/0010000000025192021
+          download: false
+
+        - name: "INSURANCE 805: SP 0001"
+          archive: K-80501ININSURANC.SAR
+          checksum: 893a3d4999c59bfd4c2c9ec4235f3b74b8afecf41144f256470795afc467be9a
+          url: https://softwaredownloads.sap.com/file/0010000000025202021
+          download: false
+
+        - name: "IS-OIL 805: SP 0001"
+          archive: K-80501INISOIL.SAR
+          checksum: 4ca83b7b0e9ffa174472ed367773aa070597bfe2a86ddd46a06eb0675ac4f391
+          url: https://softwaredownloads.sap.com/file/0010000000025212021
+          download: false
+
+        - name: "IS-PRA 805: SP 0001"
+          archive: K-80501INISPRA.SAR
+          checksum: 6ab9096c799abe0535e22808fb7fc092ae3fbd071360f072dab7c6ea30056fef
+          url: https://softwaredownloads.sap.com/file/0010000000025222021
+          download: false
+
+        - name: "IS-PS-CA 805: SP 0001"
+          archive: K-80501INISPSCA.SAR
+          checksum: faeebe12ee9ad7a6a202ba1f1538b47d065af214812b96bc400e9a681267ee7a
+          url: https://softwaredownloads.sap.com/file/0010000000025232021
+          download: false
+
+        - name: "IS-UT 805: SP 0001"
+          archive: K-80501INISUT.SAR
+          checksum: f6f1f36bb905b44980f327ece0d97c9ed636ec17c0a3392c258d260426dea005
+          url: https://softwaredownloads.sap.com/file/0010000000025242021
+          download: false
+
+        - name: "MDG_APPL 805: SP 0001"
+          archive: K-80501INMDGAPPL.SAR
+          checksum: 1742ca67b9510108bd0314a98ffdadadb6b209a85d6d902c4c6722b1f9352e6a
+          url: https://softwaredownloads.sap.com/file/0010000000025252021
+          download: false
+
+        - name: "MDG_FND 805: SP 0001"
+          archive: K-80501INMDGFND.SAR
+          checksum: 9cebe04f7e21009260d254557f4bb74e6e63531284fdcf5a2088e9a05ff5f4e6
+          url: https://softwaredownloads.sap.com/file/0010000000025262021
+          download: false
+
+        - name: "EA-DFPS 805: SP 0002"
+          archive: K-80502INEADFPS.SAR
+          checksum: 72240c827702c5534d07ff9af998046e4e252e6b970b08a0a5cef3ee0945d643
+          url: https://softwaredownloads.sap.com/file/0010000000595522021
+          download: false
+
+        - name: "EA-PS 805: SP 0002"
+          archive: K-80502INEAPS.SAR
+          checksum: 04602fcfd313288a8c6f838a201f23371edde134d9de7c75b5344ded40314a1a
+          url: https://softwaredownloads.sap.com/file/0010000000595532021
+          download: false
+
+        - name: "FI-CAX 805: SP 0002"
+          archive: K-80502INFICAX.SAR
+          checksum: 8c0505104315ea48bf3c52afe3fdf71a7fdb0b70eef593bba55a83ca39dae0ec
+          url: https://softwaredownloads.sap.com/file/0010000000595542021
+          download: false
+
+        - name: "INSURANCE 805: SP 0002"
+          archive: K-80502ININSURANC.SAR
+          checksum: dbdaa5727ba845d14eacff611bd6e28b4580a689909023d48789577ab0820f5e
+          url: https://softwaredownloads.sap.com/file/0010000000595552021
+          download: false
+
+        - name: "IS-OIL 805: SP 0002"
+          archive: K-80502INISOIL.SAR
+          checksum: f27196a3d30e96113b118059983a8ae7816146a2f9ffc7496a51902778e446ee
+          url: https://softwaredownloads.sap.com/file/0010000000595562021
+          download: false
+
+        - name: "IS-PRA 805: SP 0002"
+          archive: K-80502INISPRA.SAR
+          checksum: 956ff8668f3578f4adf3366b04b226fa5edd19f08b2fb68d93c033b9099ce990
+          url: https://softwaredownloads.sap.com/file/0010000000595572021
+          download: false
+
+        - name: "IS-PS-CA 805: SP 0002"
+          archive: K-80502INISPSCA.SAR
+          checksum: 753c05ce51bf10977fb5d8873f9829bbc219c1915234e78b35c011bb7bd50e30
+          url: https://softwaredownloads.sap.com/file/0010000000595582021
+          download: false
+
+        - name: "IS-UT 805: SP 0002"
+          archive: K-80502INISUT.SAR
+          checksum: 4920e3d685b974ccddc467243eb761357899cd942a1bd0e63051609ffecb16a3
+          url: https://softwaredownloads.sap.com/file/0010000000595592021
+          download: false
+
+        - name: "MDG_APPL 805: SP 0002"
+          archive: K-80502INMDGAPPL.SAR
+          checksum: 3dfc40e3087f148c50d7d1eff0706bfb2aa052a8169b37844bb1d40afad38bbe
+          url: https://softwaredownloads.sap.com/file/0010000000595602021
+          download: false
+
+        - name: "MDG_FND 805: SP 0002"
+          archive: K-80502INMDGFND.SAR
+          checksum: ee8c9427c5bfcd777328f1ec574d28d979b3ab8cb5de08cc23ea2e4beb4587a0
+          url: https://softwaredownloads.sap.com/file/0010000000595612021
+          download: false
+
+        - name: "EA-DFPS 805: SP 0003"
+          archive: K-80503INEADFPS.SAR
+          checksum: fe183e02cd0fc36d39bb8f3505f22102eba2c5c971e1a04216cbbb33c4b510f6
+          url: https://softwaredownloads.sap.com/file/0010000001433152021
+          download: false
+
+        - name: "EA-PS 805: SP 0003"
+          archive: K-80503INEAPS.SAR
+          checksum: 142e978321bd58c79ec4a703b37f8e34e28aba24adf582e11a381b615005f249
+          url: https://softwaredownloads.sap.com/file/0010000001433162021
+          download: false
+
+        - name: "FI-CAX 805: SP 0003"
+          archive: K-80503INFICAX.SAR
+          checksum: 813adcba3f8c7203b8694c3a78536d170fd45f2277f6682928907ec82834dc1d
+          url: https://softwaredownloads.sap.com/file/0010000001433172021
+          download: false
+
+        - name: "INSURANCE 805: SP 0003"
+          archive: K-80503ININSURANC.SAR
+          checksum: bddea11dea9f1e2676eb035173b534f5851b0880799af98350969acdfacdf85a
+          url: https://softwaredownloads.sap.com/file/0010000001433182021
+          download: false
+
+        - name: "IS-OIL 805: SP 0003"
+          archive: K-80503INISOIL.SAR
+          checksum: c22a6ad1f2cb7535d5ac950c22abf7aabd35ba6b567474159a9b655f3782b50b
+          url: https://softwaredownloads.sap.com/file/0010000001433192021
+          download: false
+
+        - name: "IS-PRA 805: SP 0003"
+          archive: K-80503INISPRA.SAR
+          checksum: 75661aa0a341d515b1340fb632d722d0c8b93e42c6c756659d5c5c3fea1144f6
+          url: https://softwaredownloads.sap.com/file/0010000001433212021
+          download: false
+
+        - name: "IS-PS-CA 805: SP 0003"
+          archive: K-80503INISPSCA.SAR
+          checksum: cc135940a8a9db1e33be94d5e2b877c799e80aa27f25b7767e037f6b04c316e4
+          url: https://softwaredownloads.sap.com/file/0010000001433222021
+          download: false
+
+        - name: "IS-UT 805: SP 0003"
+          archive: K-80503INISUT.SAR
+          checksum: 100b1b2a083d9f3b823a7aee9311cdd1bc220b3e585c3f159c0836905dcaa8eb
+          url: https://softwaredownloads.sap.com/file/0010000001433242021
+          download: false
+
+        - name: "MDG_APPL 805: SP 0003"
+          archive: K-80503INMDGAPPL.SAR
+          checksum: 2056ac8ed72a72cbba4772160bc233223efe03fdb222d671378b7055f415f6e4
+          url: https://softwaredownloads.sap.com/file/0010000001433252021
+          download: false
+
+        - name: "MDG_FND 805: SP 0003"
+          archive: K-80503INMDGFND.SAR
+          checksum: 10af40cb72870ba2857cf51a19dcefef1736d934416776919b026a11d98276d8
+          url: https://softwaredownloads.sap.com/file/0010000001433262021
+          download: false
+
+        - name: "SPAM/SAINT Update - Version 755/0082"
+          archive: KD75582.SAR
+          checksum: 68097daa731e29cf57be08dae0009248ea67e11c903c5388807059b821311d3e
+          url: https://softwaredownloads.sap.com/file/0010000000652292022
+          download: false
+
+        - name: "SAP_HR 608: SP 0083"
+          archive: KE60883.SAR
+          checksum: 02b35c133b2aa72887085cbbf9c876d628077ed2da37cda311c204b6c88aa1a4
+          url: https://softwaredownloads.sap.com/file/0010000001324772020
+          download: false
+
+        - name: "SAP_HR 608: SP 0084"
+          archive: KE60884.SAR
+          checksum: 77e7373357923c82612850831630ce10090b4ab1cc6aa3bef39eb50ee40141d8
+          url: https://softwaredownloads.sap.com/file/0010000001507762020
+          download: false
+
+        - name: "SAP_HR 608: SP 0085"
+          archive: KE60885.SAR
+          checksum: 44eea91c31849457ea6019deb8ff29bb7b147791abf6feb6a2d678767ec1ef66
+          url: https://softwaredownloads.sap.com/file/0010000001676522020
+          download: false
+
+        - name: "SAP_HR 608: SP 0086"
+          archive: KE60886.SAR
+          checksum: ae2995470e261f906f029bb71dabb19d4d94dd9feb78342b18c13ab9ce37c98c
+          url: https://softwaredownloads.sap.com/file/0010000001888812020
+          download: false
+
+        - name: "SAP_HR 608: SP 0087"
+          archive: KE60887.SAR
+          checksum: 949d65f75c97c982587f96178472a5ca214023638680ba147868692a6ecd6b40
+          url: https://softwaredownloads.sap.com/file/0010000002067072020
+          download: false
+
+        - name: "SAP_HR 608: SP 0088"
+          archive: KE60888.SAR
+          checksum: a0df3ac6af2481f35cb8167eeb0d778e0aabf1410556e372e319692e07548d7c
+          url: https://softwaredownloads.sap.com/file/0010000002135522020
+          download: false
+
+        - name: "SAP_HR 608: SP 0089"
+          archive: KE60889.SAR
+          checksum: 28d2cb00a3e643c6eba7e8c373d47714929e0de97bb39d4a9b56b9208994b487
+          url: https://softwaredownloads.sap.com/file/0010000000065492021
+          download: false
+
+        - name: "SAP_HR 608: SP 0090"
+          archive: KE60890.SAR
+          checksum: ccc77cb17ed5f117d2a7a685ed4a5ef321953b9c778d9bcbd2f816015644af2c
+          url: https://softwaredownloads.sap.com/file/0010000000184572021
+          download: false
+
+        - name: "SAP_HR 608: SP 0091"
+          archive: KE60891.SAR
+          checksum: fc45e3265e38fb699a70e8bb6f1c291f06501286fc9974465853ce978e75f1c3
+          url: https://softwaredownloads.sap.com/file/0010000000340862021
+          download: false
+
+        - name: "SAP_HR 608: SP 0092"
+          archive: KE60892.SAR
+          checksum: 14ceb8d360775e1ada58a766a00c713d4b862f210f547942f8dbdcd7a336fc70
+          url: https://softwaredownloads.sap.com/file/0010000000545482021
+          download: false
+
+        - name: "SAP_HR 608: SP 0093"
+          archive: KE60893.SAR
+          checksum: 4723592215209ce60f1f7be3f983cda2c79da1f19a7223cf0d49bd6721e83cab
+          url: https://softwaredownloads.sap.com/file/0010000000679612021
+          download: false
+
+        - name: "SAP_HR 608: SP 0094"
+          archive: KE60894.SAR
+          checksum: cd16343fce0aafe6f27256dd114636c243cc82dbd26f4a69a7dced4de02eefe4
+          url: https://softwaredownloads.sap.com/file/0010000000817222021
+          download: false
+
+        - name: "SAP_HR 608: SP 0095"
+          archive: KE60895.SAR
+          checksum: 41ddbc52887e98b53d2d37c3efa273b563346fc614e8ebd9c49c04b2e6b50dbc
+          url: https://softwaredownloads.sap.com/file/0010000000999632021
+          download: false
+
+        - name: "SAP_HR 608: SP 0096"
+          archive: KE60896.SAR
+          checksum: f5f3c3d4ce6c96e78a4aad39144183b6f67a26abd57525366bf797077fab772f
+          url: https://softwaredownloads.sap.com/file/0010000001143002021
+          download: false
+
+        - name: "SAP_HR 608: SP 0097"
+          archive: KE60897.SAR
+          checksum: 4065937f917e5f43123d38ab8098f4acbf76888ede86f7c5690ec3bb2e641085
+          url: https://softwaredownloads.sap.com/file/0010000001272002021
+          download: false
+
+        - name: "Servicetools for SAP Basis 731 and higher"
+          archive: KITAB9Z.SAR
+          checksum: 230dab337a626543a3015d19888aff5fa1483fb0e7710b6559319c521f84f154
+          url: https://softwaredownloads.sap.com/file/0010000001758902020
+          download: false
+
+        - name: "Attribute Change Package 10 for SAP_BASIS 755"
+          archive: SAP_BASIS755.SAR
+          checksum: 8145454f9a9851af3f6c4d6ebf31e7f179c5e9f8250efeef5055a7580872577b
+          url: https://softwaredownloads.sap.com/file/0010000001467632021
+          download: false
+
+        - name: "Attribute Change Package 37 for SAP_HR 608"
+          archive: SAP_HR608.SAR
+          checksum: 21055a344d47909f65f40a1c6febf7268650ea2623e6bfbef2f68b607388d469
+          url: https://softwaredownloads.sap.com/file/0010000000249512014
+          download: false
+
+        - name: "Attribute Change Package 04 for SAP_UI 755"
+          archive: SAP_UI755.SAR
+          checksum: ac15136030130fcdbe11529f971f873674fb7abcdc2815d9bb4c11659ce04603
+          url: https://softwaredownloads.sap.com/file/0010000000211202021
+          download: false
+
+        - name: "Attribute Change Package 23 for SRA004 600"
+          archive: SRA004600.SAR
+          checksum: ae231eadcb360d1be79959357036814874eefa92d7988c5a2c65d9c26cc173af
+          url: https://softwaredownloads.sap.com/file/0010000000060132013
+          download: false
+
+        - name: "Attribute Change Package 56 for ST-PI 740"
+          archive: ST-PI740.SAR
+          checksum: 564fcbe7d359516cb09d21098223dd87ca81873777e7d3ab36a2a73b2406871c
+          url: https://softwaredownloads.sap.com/file/0010000000297212015
+          download: false
+
+        - name: "Attribute Change Package 01 for UIBAS001 600"
+          archive: UIBAS001600.SAR
+          checksum: d69cd7b88f4f5adf04b44c882fa98f7687e062f3b8da02149186e74f510cad8a
+          url: https://softwaredownloads.sap.com/file/0010000001415322021
+          download: false
+
+# Web Dispatcher
+
+        - name:           "Support Package SAP WEB DISPATCHER 7.81 Linux on x86_64 64bit"
+          archive:        SAPWEBDISP_SP_110-70005393.SAR
+          checksum:       706e5f4eab5d8a3573c3cc2bf6695562b8c71c59b5079e2f7e7b8afb283ee5fc
+          url:            https://softwaredownloads.sap.com/file/0020000000314542021
+          download:       true
+
+...

--- a/SAP/S42020ISS00_v0003ms/templates/HANA_2_00_055_v1_install.rsp.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/HANA_2_00_055_v1_install.rsp.j2
@@ -1,0 +1,305 @@
+[General]
+
+# Location of Installation Medium
+component_medium=
+
+# Comma separated list of component directories
+component_dirs=
+
+# Use single master password for all users, created during installation ( Default: n )
+use_master_password=n
+
+# Directory root to search for components
+component_root={{ _rsp_component_root }}
+
+# Skip all SAP Host Agent calls ( Default: n )
+skip_hostagent_calls=n
+
+# Remote Execution ( Default: ssh; Valid values: ssh | saphostagent )
+remote_execution=ssh
+
+# Verify the authenticity of SAP HANA components ( Default: n )
+verify_signature=n
+
+# Components ( Valid values: all | client | es | ets | lcapps | server | smartda | streaming | rdsync | xs | studio | afl | sca | sop | eml | rme | rtl | trp )
+components={{ _rsp_components }}
+
+# Install Execution Mode ( Default: standard; Valid values: standard | optimized )
+install_execution_mode=standard
+
+# Ignore failing prerequisite checks
+ignore=
+
+# Do not Modify '/etc/sudoers' File ( Default: n )
+skip_modify_sudoers=n
+
+[Server]
+
+# Enable usage of persistent memory ( Default: n )
+use_pmem=n
+
+# Enable the installation or upgrade of the SAP Host Agent ( Default: y )
+install_hostagent=y
+
+# Database Isolation ( Default: low; Valid values: low | high )
+db_isolation=low
+
+# Create initial tenant database ( Default: y )
+create_initial_tenant=y
+
+# Non-standard Shared File System
+checkmnt=
+
+# Installation Path ( Default: /hana/shared )
+sapmnt={{ _rsp_sapmnt }}
+
+# Local Host Name ( Default: x00dhdb00l0b3a )
+hostname={{ _rsp_hostname }}
+
+# Install SSH Key ( Default: y )
+install_ssh_key=y
+
+# Root User Name For Remote Hosts ( Default: root )
+root_user=root
+
+# Root User Password For Remote Hosts
+root_password= {{ main_password }}
+
+# SAP Host Agent User (sapadm) Password
+sapadm_password= {{ main_password }}
+
+# Directory containing a storage configuration
+storage_cfg=
+
+# Listen Interface ( Valid values: global | internal | local )
+listen_interface=
+
+# Internal Network Address
+internal_network=
+
+# SAP HANA System ID
+sid={{ _rsp_sid }}
+
+# Instance Number
+number={{ _rsp_number }}
+
+# Local Host Worker Group ( Default: default )
+workergroup=default
+
+# System Usage ( Default: custom; Valid values: production | test | development | custom )
+system_usage={{ _rsp_system_usage }}
+
+# Instruct the Local Secure Store (LSS) to trust an unsigned SAP HANA Database ( Default: n )
+lss_trust_unsigned_server=n
+
+# Do you want to enable data and log volume encryption? ( Default: n )
+volume_encryption=n
+
+# Location of Data Volumes ( Default: /hana/data/${sid} )
+datapath=/hana/data/${sid}
+
+# Location of Log Volumes ( Default: /hana/log/${sid} )
+logpath=/hana/log/${sid}
+
+# Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
+pmempath=/hana/pmem/${sid}
+
+# Directory containing custom configurations
+custom_cfg=
+
+# SAP HANA Database secure store ( Default: ssfs; Valid values: ssfs | localsecurestore )
+secure_store=ssfs
+
+# Restrict maximum memory allocation?
+restrict_max_mem=
+
+# Maximum Memory Allocation in MB
+max_mem=
+
+# Certificate Host Names
+certificates_hostmap=
+
+# Master Password
+master_password=
+
+# System Administrator Password, do not set for S41909
+password={{ main_password }}
+
+# System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
+home=/usr/sap/${sid}/home
+
+# System Administrator Login Shell ( Default: /bin/sh )
+shell=/bin/sh
+
+# System Administrator User ID
+userid={{ hdbadm_uid }}
+
+# ID of User Group (sapsys)
+groupid={{ sapsys_gid }}
+
+# Database User (SYSTEM) Password
+system_user_password={{ main_password }}
+
+# Restart system after machine reboot? ( Default: n )
+autostart=n
+
+# Enable HANA repository ( Default: y )
+repository=y
+
+# Inter Service Communication Mode ( Valid values: standard | ssl )
+isc_mode=
+
+[Action]
+
+# Action ( Default: exit; Valid values: install | update | extract_components )
+action=install
+
+[AddHosts]
+
+# Auto Initialize Services ( Default: y )
+auto_initialize_services=y
+
+# Additional Hosts
+addhosts=
+
+# Additional Local Host Roles ( Valid values: extended_storage_worker | extended_storage_standby | ets_worker | ets_standby | streaming | xs_worker | xs_standby )
+add_local_roles=
+
+# Automatically assign XS Advanced Runtime roles to the hosts with database roles (y/n) ( Default: y )
+autoadd_xs_roles=y
+
+# Import initial content of XS Advanced Runtime ( Default: y )
+import_xs_content=y
+
+[Client]
+
+# SAP HANA Database Client Installation Path ( Default: ${sapmnt}/${sid}/hdbclient )
+client_path=/hana/shared/${sid}/hdbclient
+
+[Studio]
+
+# SAP HANA Studio Installation Path ( Default: ${sapmnt}/${sid}/hdbstudio )
+studio_path=/hana/shared/${sid}/hdbstudio
+
+# Enables copying of SAP HANA Studio repository ( Default: y )
+studio_repository=y
+
+# Target path to which SAP HANA Studio repository should be copied
+copy_repository=
+
+# Java Runtime ( Default:  )
+vm=
+
+[Reference_Data]
+
+# Installation Path for Address Directories and Reference Data
+reference_data_path=
+
+[XS_Advanced]
+
+# Install XS Advanced in the default tenant database? (y/n) ( Default: n )
+xs_use_default_tenant=n
+
+# XS Advanced App Working Path
+xs_app_working_path=
+
+# Organization Name For Space "SAP" ( Default: orgname )
+org_name=orgname
+
+# XS Advanced Admin User ( Default: XSA_ADMIN )
+org_manager_user=XSA_ADMIN
+
+# XS Advanced Admin User Password
+org_manager_password=
+
+# Customer Space Name ( Default: PROD )
+prod_space_name=PROD
+
+# Routing Mode ( Default: ports; Valid values: ports | hostnames )
+xs_routing_mode=ports
+
+# XS Advanced Domain Name (see SAP Note 2245631)
+xs_domain_name=
+
+# Run Applications in SAP Space with Separate OS User (y/n) ( Default: y )
+xs_sap_space_isolation=y
+
+# Run Applications in Customer Space with Separate OS User (y/n) ( Default: y )
+xs_customer_space_isolation=y
+
+# XS Advanced SAP Space OS User ID
+xs_sap_space_user_id=
+
+# XS Advanced Customer Space OS User ID
+xs_customer_space_user_id=
+
+# XS Advanced Components
+xs_components=
+
+# Do not start the selected XS Advanced components after installation ( Default: none )
+xs_components_nostart=none
+
+# XS Advanced Components Configurations
+xs_components_cfg=
+
+# XS Advanced Certificate
+xs_cert_pem=
+
+# XS Advanced Certificate Key
+xs_cert_key=
+
+# XS Advanced Trust Certificate
+xs_trust_pem=
+
+[lss]
+
+# Installation Path for Local Secure Store ( Default: /lss/shared )
+lss_inst_path=/lss/shared
+
+# Local Secure Store User Password
+lss_user_password=
+
+# Local Secure Store User ID
+lss_userid=
+
+# Local Secure Store User Group ID
+lss_groupid=
+
+# Local Secure Store User Home Directory ( Default: /usr/sap/${sid}/lss/home )
+lss_user_home=/usr/sap/${sid}/lss/home
+
+# Local Secure Store User Login Shell ( Default: /bin/sh )
+lss_user_shell=/bin/sh
+
+# Local Secure Store Auto Backup Password
+lss_backup_password=
+
+[streaming]
+
+# Streaming Cluster Manager Password
+streaming_cluster_manager_password=
+
+# Location of Streaming logstores and runtime information ( Default: /hana/data_streaming/${sid} )
+basepath_streaming=/hana/data_streaming/${sid}
+
+[es]
+
+# Location of Dynamic Tiering Data Volumes ( Default: /hana/data_es/${sid} )
+es_datapath=/hana/data_es/${sid}
+
+# Location of Dynamic Tiering Log Volumes ( Default: /hana/log_es/${sid} )
+es_logpath=/hana/log_es/${sid}
+
+[ets]
+
+# Location of Data Volumes of the Accelerator for SAP ASE ( Default: /hana/data_ase/${sid} )
+ase_datapath=/hana/data_ase/${sid}
+
+# Location of Log Volumes of the Accelerator for SAP ASE ( Default: /hana/log_ase/${sid} )
+ase_logpath=/hana/log_ase/${sid}
+
+# SAP ASE Administrator User ( Default: sa )
+ase_user=sa
+
+# SAP ASE Administrator Password
+ase_user_password=

--- a/SAP/S42020ISS00_v0003ms/templates/HANA_2_00_install.rsp.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/HANA_2_00_install.rsp.j2
@@ -1,0 +1,305 @@
+[General]
+
+# Location of Installation Medium
+component_medium=
+
+# Comma separated list of component directories
+component_dirs=
+
+# Use single master password for all users, created during installation ( Default: n )
+use_master_password=y
+
+# Directory root to search for components
+component_root={{ _rsp_component_root }}
+
+# Skip all SAP Host Agent calls ( Default: n )
+skip_hostagent_calls=n
+
+# Remote Execution ( Default: ssh; Valid values: ssh | saphostagent )
+remote_execution=ssh
+
+# Verify the authenticity of SAP HANA components ( Default: n )
+verify_signature=n
+
+# Components ( Valid values: all | client | es | ets | lcapps | server | smartda | streaming | rdsync | xs | studio | afl | sca | sop | eml | rme | rtl | trp )
+components={{ _rsp_components }}
+
+# Install Execution Mode ( Default: standard; Valid values: standard | optimized )
+install_execution_mode=standard
+
+# Ignore failing prerequisite checks
+ignore=
+
+# Do not Modify '/etc/sudoers' File ( Default: n )
+skip_modify_sudoers=n
+
+[Server]
+
+# Enable usage of persistent memory ( Default: n )
+use_pmem=n
+
+# Enable the installation or upgrade of the SAP Host Agent ( Default: y )
+install_hostagent=y
+
+# Database Isolation ( Default: low; Valid values: low | high )
+db_isolation=low
+
+# Create initial tenant database ( Default: y )
+create_initial_tenant=y
+
+# Non-standard Shared File System
+checkmnt=
+
+# Installation Path ( Default: /hana/shared )
+sapmnt={{ _rsp_sapmnt }}
+
+# Local Host Name ( Default: x00dhdb00l0b3a )
+hostname={{ _rsp_hostname }}
+
+# Install SSH Key ( Default: y )
+install_ssh_key=y
+
+# Root User Name For Remote Hosts ( Default: root )
+root_user=root
+
+# Root User Password For Remote Hosts
+root_password= {{ main_password }}
+
+# SAP Host Agent User (sapadm) Password
+sapadm_password= {{ main_password }}
+
+# Directory containing a storage configuration
+storage_cfg=
+
+# Listen Interface ( Valid values: global | internal | local )
+listen_interface=
+
+# Internal Network Address
+internal_network=
+
+# SAP HANA System ID
+sid={{ _rsp_sid }}
+
+# Instance Number
+number={{ _rsp_number }}
+
+# Local Host Worker Group ( Default: default )
+workergroup=default
+
+# System Usage ( Default: custom; Valid values: production | test | development | custom )
+system_usage={{ _rsp_system_usage }}
+
+# Instruct the Local Secure Store (LSS) to trust an unsigned SAP HANA Database ( Default: n )
+lss_trust_unsigned_server=n
+
+# Do you want to enable data and log volume encryption? ( Default: n )
+volume_encryption=n
+
+# Location of Data Volumes ( Default: /hana/data/${sid} )
+datapath=/hana/data/${sid}
+
+# Location of Log Volumes ( Default: /hana/log/${sid} )
+logpath=/hana/log/${sid}
+
+# Location of Persistent Memory Volumes ( Default: /hana/pmem/${sid} )
+pmempath=/hana/pmem/${sid}
+
+# Directory containing custom configurations
+custom_cfg=
+
+# SAP HANA Database secure store ( Default: ssfs; Valid values: ssfs | localsecurestore )
+secure_store=ssfs
+
+# Restrict maximum memory allocation?
+restrict_max_mem=
+
+# Maximum Memory Allocation in MB
+max_mem=
+
+# Certificate Host Names
+certificates_hostmap=
+
+# Master Password
+master_password={{ main_password }}
+
+# System Administrator Password
+password=
+
+# System Administrator Home Directory ( Default: /usr/sap/${sid}/home )
+home=/usr/sap/${sid}/home
+
+# System Administrator Login Shell ( Default: /bin/sh )
+shell=/bin/sh
+
+# System Administrator User ID
+userid={{ hdbadm_uid }}
+
+# ID of User Group (sapsys)
+groupid={{ sapsys_gid }}
+
+# Database User (SYSTEM) Password
+system_user_password=
+
+# Restart system after machine reboot? ( Default: n )
+autostart=n
+
+# Enable HANA repository ( Default: y )
+repository=y
+
+# Inter Service Communication Mode ( Valid values: standard | ssl )
+isc_mode=
+
+[Action]
+
+# Action ( Default: exit; Valid values: install | update | extract_components )
+action=install
+
+[AddHosts]
+
+# Auto Initialize Services ( Default: y )
+auto_initialize_services=y
+
+# Additional Hosts
+addhosts=
+
+# Additional Local Host Roles ( Valid values: extended_storage_worker | extended_storage_standby | ets_worker | ets_standby | streaming | xs_worker | xs_standby )
+add_local_roles=
+
+# Automatically assign XS Advanced Runtime roles to the hosts with database roles (y/n) ( Default: y )
+autoadd_xs_roles=y
+
+# Import initial content of XS Advanced Runtime ( Default: y )
+import_xs_content=y
+
+[Client]
+
+# SAP HANA Database Client Installation Path ( Default: ${sapmnt}/${sid}/hdbclient )
+client_path=/hana/shared/${sid}/hdbclient
+
+[Studio]
+
+# SAP HANA Studio Installation Path ( Default: ${sapmnt}/${sid}/hdbstudio )
+studio_path=/hana/shared/${sid}/hdbstudio
+
+# Enables copying of SAP HANA Studio repository ( Default: y )
+studio_repository=y
+
+# Target path to which SAP HANA Studio repository should be copied
+copy_repository=
+
+# Java Runtime ( Default:  )
+vm=
+
+[Reference_Data]
+
+# Installation Path for Address Directories and Reference Data
+reference_data_path=
+
+[XS_Advanced]
+
+# Install XS Advanced in the default tenant database? (y/n) ( Default: n )
+xs_use_default_tenant=n
+
+# XS Advanced App Working Path
+xs_app_working_path=
+
+# Organization Name For Space "SAP" ( Default: orgname )
+org_name=orgname
+
+# XS Advanced Admin User ( Default: XSA_ADMIN )
+org_manager_user=XSA_ADMIN
+
+# XS Advanced Admin User Password
+org_manager_password=
+
+# Customer Space Name ( Default: PROD )
+prod_space_name=PROD
+
+# Routing Mode ( Default: ports; Valid values: ports | hostnames )
+xs_routing_mode=ports
+
+# XS Advanced Domain Name (see SAP Note 2245631)
+xs_domain_name=
+
+# Run Applications in SAP Space with Separate OS User (y/n) ( Default: y )
+xs_sap_space_isolation=y
+
+# Run Applications in Customer Space with Separate OS User (y/n) ( Default: y )
+xs_customer_space_isolation=y
+
+# XS Advanced SAP Space OS User ID
+xs_sap_space_user_id=
+
+# XS Advanced Customer Space OS User ID
+xs_customer_space_user_id=
+
+# XS Advanced Components
+xs_components=
+
+# Do not start the selected XS Advanced components after installation ( Default: none )
+xs_components_nostart=none
+
+# XS Advanced Components Configurations
+xs_components_cfg=
+
+# XS Advanced Certificate
+xs_cert_pem=
+
+# XS Advanced Certificate Key
+xs_cert_key=
+
+# XS Advanced Trust Certificate
+xs_trust_pem=
+
+[lss]
+
+# Installation Path for Local Secure Store ( Default: /lss/shared )
+lss_inst_path=/lss/shared
+
+# Local Secure Store User Password
+lss_user_password=
+
+# Local Secure Store User ID
+lss_userid=
+
+# Local Secure Store User Group ID
+lss_groupid=
+
+# Local Secure Store User Home Directory ( Default: /usr/sap/${sid}/lss/home )
+lss_user_home=/usr/sap/${sid}/lss/home
+
+# Local Secure Store User Login Shell ( Default: /bin/sh )
+lss_user_shell=/bin/sh
+
+# Local Secure Store Auto Backup Password
+lss_backup_password=
+
+[streaming]
+
+# Streaming Cluster Manager Password
+streaming_cluster_manager_password=
+
+# Location of Streaming logstores and runtime information ( Default: /hana/data_streaming/${sid} )
+basepath_streaming=/hana/data_streaming/${sid}
+
+[es]
+
+# Location of Dynamic Tiering Data Volumes ( Default: /hana/data_es/${sid} )
+es_datapath=/hana/data_es/${sid}
+
+# Location of Dynamic Tiering Log Volumes ( Default: /hana/log_es/${sid} )
+es_logpath=/hana/log_es/${sid}
+
+[ets]
+
+# Location of Data Volumes of the Accelerator for SAP ASE ( Default: /hana/data_ase/${sid} )
+ase_datapath=/hana/data_ase/${sid}
+
+# Location of Log Volumes of the Accelerator for SAP ASE ( Default: /hana/log_ase/${sid} )
+ase_logpath=/hana/log_ase/${sid}
+
+# SAP ASE Administrator User ( Default: sa )
+ase_user=sa
+
+# SAP ASE Administrator Password
+ase_user_password=

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-app-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-app-inifile-param.j2
@@ -1,0 +1,52 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP                                                                                           #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAP'                                                                                      #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAP'                                                                                    #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP'                                                                  #
+#                       > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:S4HANA2020.CORE.HDB.PD'                                                         #
+#                       Generic Options > SAP HANA Database > Preparations > Operating System Users and Groups', product id 'NW_Users_Create:GENERIC.HDB.PD'                                           #
+########################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                               = /usr/sap/install/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+NW_AS.instanceNumber                                                  = {{ app_instance_number }}
+NW_DI_Instance.virtualHostname                                        = {{ sap_appVirtualHostname }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPHANADB
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.instanceNumber                                       = {{ hdb_instance_number }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}
+
+# Database hostnames that will be set directly in hdbuserstore without resolving them in HANA. Comma separated. Example (host1,host2)
+HDB_Userstore.doNotResolveHostnames                                   =  {{ virt_do_not_resolve_hostname }}

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-dbload-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-dbload-inifile-param.j2
@@ -1,0 +1,41 @@
+##########################################################################################################################################################################################################
+#                                                                                                                                                                                                        #
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA2020.CORE.HDB.ABAP' #
+#                                                                                                                                                                                                        #
+##########################################################################################################################################################################################################
+
+archives.downloadBasket                          = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                = {{ sapadm_uid }}
+nwUsers.sapsysGID                                = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                = {{ sidadm_uid }}
+nwUsers.sidadmPassword                           = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers              = true
+NW_GetMasterPassword.masterPwd                   = {{ main_password }}
+
+NW_HDB_DB.abapSchemaName                         = {{ hana_schema }}
+NW_HDB_DB.abapSchemaPassword                     = {{ main_password }}
+NW_HDB_getDBInfo.dbhost                          = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbport                          = 3{{ hdb_instance_number }}15
+NW_HDB_getDBInfo.dbsid                           = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                  = {{ hdb_instance_number }}
+NW_HDB_getDBInfo.systemDbPassword                = {{ main_password }}
+NW_HDB_getDBInfo.systemPassword                  = {{ main_password }}
+NW_HDB_getDBInfo.systemid                        = {{ db_sid | upper }}
+NW_HDB_getDBInfo.usingSSL                        = true
+NW_HDB_DB.dbacockpitPassword                     = {{ main_password }}
+
+NW_Recovery_Install_HDB.extractLocation          = /hana/backup/{{ db_sid | upper }}/HDB{{ hdb_instance_number }}/backup/data/DB_{{ db_sid | upper }}{{ hdb_instance_number }}
+NW_Recovery_Install_HDB.extractParallelJobs      = 24
+NW_Recovery_Install_HDB.sidAdmName               = {{ db_sid | lower }}adm
+NW_Recovery_Install_HDB.sidAdmPassword           = {{ main_password }}
+
+NW_Unpack.sapExeDbSar                            = {{ target_media_location }}/SAPEXEDB_200-70005282.SAR
+
+NW_checkMsgServer.abapMSPort                     = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                          = SAP
+NW_readProfileDir.profileDir                     = {{ sap_profile_dir }}
+
+HDB_Schema_Check_Dialogs.schemaName              = {{ hana_schema }}
+HDB_Schema_Check_Dialogs.schemaPassword          = {{ main_password }}

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-ers-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-ers-inifile-param.j2
@@ -1,0 +1,33 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+###################################################################################################################################
+######################################################################
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP > High-Availability 
+# System > ERS Instance', product id 'NW_ERS:S4HANA2020.CORE.HDB.ABAPHA' #
+#
+###################################################################################################################################
+######################################################################
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+nwUsers.sidadmPassword                                               = {{ main_password }}
+hostAgent.sapAdmPassword                                             = {{ main_password }}
+
+nw_instance_ers.ersInstanceNumber                                    = {{ ers_instance_number }}
+nw_instance_ers.ersVirtualHostname                                   = {{ ers_virtual_hostname }}
+
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+NW_readProfileDir.profileDir                                         = /sapmnt/{{ sap_sid | upper }}/profile
+
+

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-generic-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-generic-inifile-param.j2
@@ -1,0 +1,32 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+#   Creation of user for ERS and SCS issues during HA installation - 14-03-2022
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'Generic Options > SAP HANA Database > Preparations > Operating System Users and Groups', product id 'NW_Users_Create:GENERIC.HDB.PD'                                           #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+NW_Users_Create.dbsid                                                 = {{ sap_sid | upper }}
+
+# Specify whether you are preparing for an SAP sytem based on AS ABAP.
+NW_Users_Create.hasABAP                                               = true
+
+# Specify whether database users are to be installed.
+NW_Users_Create.installDBUsers                                        = false
+
+# SAP system ID
+NW_Users_Create.sid                                                   = {{ sap_sid | upper }}
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+# Password for the 'sapadm' user of the SAP Host Agent
+hostAgent.sapAdmPassword =  {{ main_password }}
+
+
+

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-pas-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-pas-inifile-param.j2
@@ -1,0 +1,74 @@
+############################################################################################################################################################################################################################
+#
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA2020.CORE.HDB.ABAP' #
+#
+############################################################################################################################################################################################################################
+
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                         = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                               = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                               = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                               = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                               = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                               = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid | upper }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+
+HDB_Schema_Check_Dialogs.schemaName                                   = {{ hana_schema }}
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_HDB_DB.abapSchemaName                                              = {{ hana_schema }}
+NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                                       = {{ hdb_instance_number }}
+NW_HDB_getDBInfo.systemDbPassword                                     = {{ main_password }}
+NW_HDB_getDBInfo.systemPassword                                       = {{ main_password }}
+NW_HDB_getDBInfo.systemid                                             = {{ db_sid | upper }}
+NW_HDB_getDBInfo.usingSSL                                             = true
+
+NW_Recovery_Install_HDB.extractLocation                               = /usr/sap/{{ db_sid | upper }}/{{ db_sid | upper }}{{ hdb_instance_number }}/backup/data/DB_HDB
+NW_Recovery_Install_HDB.extractParallelJobs                           = 24
+NW_Recovery_Install_HDB.sidAdmName                                    = {{ db_sid | lower }}adm
+NW_Recovery_Install_HDB.sidAdmPassword                                = {{ main_password }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+NW_CI_Instance.ascsVirtualHostname                                    = {{ sap_scs_hostname }}
+NW_CI_Instance.ciInstanceNumber                                       = {{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciMSPort                                               = 36{{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciVirtualHostname                                      = {{ sap_ciVirtualHostname }}
+NW_CI_Instance.scsVirtualHostname                                     = {{ sap_scs_hostname }}
+
+NW_DDIC_Password.needDDICPasswords                                    = false
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}
+
+NW_WPConfiguration.ciDialogWPNumber                                   = {{ sap_ciDialogWPNumber}}
+NW_WPConfiguration.ciBtcWPNumber                                      = {{ sap_ciBtcWPNumber }}
+
+storageBasedCopy.hdb.instanceNumber                                   = {{ hdb_instance_number }}
+storageBasedCopy.hdb.systemPassword                                   = {{ main_password }}
+
+# Database hostnames that will be set directly in hdbuserstore without resolving them in HANA. Comma separated. Example (host1,host2)
+HDB_Userstore.doNotResolveHostnames                                   =  {{ virt_do_not_resolve_hostname }}

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-scs-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-scs-inifile-param.j2
@@ -1,0 +1,24 @@
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAP' #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = false
+NW_SCS_Instance.ascsInstallWebDispatcher                             = true
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-scsha-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-scsha-inifile-param.j2
@@ -1,0 +1,23 @@
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 2020 > SAP HANA Database > Installation > Application Server ABAP > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA2020.CORE.HDB.ABAPHA' #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-web-inifile-param.j2
+++ b/SAP/S42020ISS00_v0003ms/templates/S42020ISS00_v0003ms-web-inifile-param.j2
@@ -1,0 +1,44 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'SAP S/4HANA Server 1909 > SAP HANA Database > Installation > Application Server ABAP                                                                                           #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:S4HANA1909.CORE.HDB.ABAP'                                                                                      #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:S4HANA1909.CORE.HDB.ABAP'                                                                                    #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:S4HANA1909.CORE.HDB.ABAP'                                                                  #
+#                       > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:S4HANA1909.CORE.HDB.PD'                                                         #
+#                       > Generic Options > SAP Web Dispatcher > SAP Web Dispatcher (Unicode)', product id 'NW_Webdispatcher:NW750.IND.PD'                                                             #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+NW_GetSidNoProfiles.sid                                               = {{ web_sid| upper }}
+NW_webdispatcher_Instance.backEndSID                                  = {{ sap_sid | upper }}
+
+NW_Webdispatcher_Instance.wdInstanceNumber                            = {{ web_instance_number }}
+NW_webdispatcher_Instance.activateICF                                 = false
+
+NW_webdispatcher_Instance.msHTTPPort                                  = 81{{ sap_ciInstanceNumber }}
+NW_webdispatcher_Instance.msHost                                      = {{ sap_scs_hostname }}
+
+NW_webdispatcher_Instance.rfcHost                                     = {{ sap_scs_hostname }}
+NW_webdispatcher_Instance.wdVirtualHostname                           = {{ sap_webVirtualHostname }}
+
+NW_webdispatcher_Instance.scenarioSize                                = 500
+NW_webdispatcher_Instance.wdHTTPPort                                  = 80{{ web_instance_number }}
+NW_webdispatcher_Instance.wdHTTPSPort                                 = 443{{ web_instance_number }}
+
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}


### PR DESCRIPTION
This PR talks about adding Folders for S4 HANA 1909 and 2020 to cover for ISS 00. These BOM will be required to install ISS 00 versions and additionally provide SPS 03 downloads which can be leveraged by customers for further update of system if needed. 


