### PR TITLE
Add initial YAML configuration for HANA Revision 86 installation

### DIFF
--- a/SAP/HANA_2_00_086_v0001ms/HANA_2_00_086_v0001ms.yaml
+++ b/SAP/HANA_2_00_086_v0001ms/HANA_2_00_086_v0001ms.yaml
@@ -1,0 +1,70 @@
+---
+name:                                        'HANA_2_00_086_v0001ms'
+target:                                      'HANA 2.0'
+version:                                      2
+platform:                                    'HANA'
+materials:
+
+  media:
+    # SAPCAR 7.53
+    - name:                                  "SAPCAR 7.53; OS: Linux on x86_64 64bit"
+      archive:                               SAPCAR_1400-70007716.EXE
+      checksum:                              32fe4adb98c5f9238b6237fc06edc2603648295dd3d35f6b6d1fad1cbc9f24c8
+      filename:                              SAPCAR
+      permissions:                           '0755'
+      path:                                  downloads
+      url:                                   https://softwaredownloads.sap.com/file/0020000000488622025
+
+    # HANA Client v2.25
+    - name:                                  "SAP HANA CLIENT Version 2.25"
+      archive:                               IMDB_CLIENT20_025_22-80002082.SAR
+      checksum:                              ae33b5c22879ad2f15fafe6be9a784b191882921e4e593b9caf7d787344e9042
+      extract:                               true
+      extractDir:                            CD_HDBCLIENT
+      creates:                               SIGNATURE.SMF
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000641242025
+
+    # v2_00_086 Revision 2.00.086.0 (SPS08) for HANA DB 2.0
+    - name:                                  "SAP HANA 2 SPS08 Revision 086.0 (SPS08)"
+      archive:                               IMDB_SERVER20_086_0-80002031.SAR
+      checksum:                              f1a589970f2947843979de19721022077ba329eb2f0923580155ad667d3f8712
+      extract:                               true
+      extractDir:                            CD_HDBSERVER
+      creates:                               SIGNATURE.SMF
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0025000000038962025
+
+    - name:                                  "SAP HANA AFL Rev 86.0 only for HANA 2.0"
+      archive:                               IMDB_AFL20_086_0-80001894.SAR
+      checksum:                              5cdc51c830ffd2ceaf5c1e6b93c8d5e5fd3a53ade7520bba9598c022888f1a7c
+      extract:                               true
+      extractDir:                            CD_HDBSERVER/COMPONENTS
+      creates:                               COMPONENTS/SAP_HANA_AFL/packages
+      url:                                   https://softwaredownloads.sap.com/file/0020000000727902025
+
+    - name:                                  "LCAPPS for HANA 2.0 Rev 85 Build 101.18 PL 002"
+      archive:                               IMDB_LCAPPS_2086_0-20010426.SAR
+      checksum:                              c00b24b88a9e322a573e5d398720a7b230b04f90e97e3dbe5cfc2678d2373e8e
+      extract:                               true
+      extractDir:                            CD_HDBSERVER/COMPONENTS
+      creates:                               COMPONENTS/SAP_HANA_LCAPPS/packages
+      url:                                   https://softwaredownloads.sap.com/file/0020000000728002025
+
+    - name:                                  "VCH AFL 2021 Rev 86.0 only for HANA 2.0 Rev 86"
+      archive:                               VCH202100_2086_0-70006349.SAR
+      checksum:                              8de4a04cd9094ebdf585f3d10943addc6c2bddd3dd893fd3c79abe08a9be95e6
+      extract:                               true
+      extractDir:                            CD_HDBSERVER/COMPONENTS
+      creates:                               COMPONENTS/VCH_AFL_2021/packages
+      url:                                   https://softwaredownloads.sap.com/file/0020000000728102025
+
+    - name:                                  "SAP Host Agent"
+      archive:                               SAPHOSTAGENT66_66-80004822.SAR
+      checksum:                              b722469aaa23247055214f42d0bb49c8506ed8faac177a5b1a48087e4cb6d8e0
+      extract:                               false
+      download:                              true
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000001380962024
+
+...

--- a/SAP/NW750SPS20_v0008ms/NW750SPS20_v0008ms.yaml
+++ b/SAP/NW750SPS20_v0008ms/NW750SPS20_v0008ms.yaml
@@ -2,7 +2,7 @@
 # Download time:                             xx Minutes (Full    - xx GB)
 # Download time:                             xx Minutes (Partial - xx GB)
 #
-name:                                        NW750SPS20_v0007ms
+name:                                        NW750SPS20_v0008ms
 target:                                      NETWEAVER 7.50 SPS 20
 version:                                     006
 

--- a/SAP/NW750SPS20_v0008ms/NW750SPS20_v0008ms.yaml
+++ b/SAP/NW750SPS20_v0008ms/NW750SPS20_v0008ms.yaml
@@ -1,0 +1,728 @@
+---
+# Download time:                             xx Minutes (Full    - xx GB)
+# Download time:                             xx Minutes (Partial - xx GB)
+#
+name:                                        NW750SPS20_v0007ms
+target:                                      NETWEAVER 7.50 SPS 20
+version:                                     006
+
+product_ids:
+  dbl:                                       NW_ABAP_DB:NW750.HDB.ABAP
+  scs:                                       NW_ABAP_ASCS:NW750.HDB.ABAP
+  scs_ha:                                    NW_ABAP_ASCS:NW750.HDB.ABAPHA
+  pas:                                       NW_ABAP_CI:NW750.HDB.ABAP
+  pas_ha:                                    NW_ABAP_CI:NW750.HDB.ABAPHA
+  app:                                       NW_DI:NW750.HDB.PD
+  app_ha:                                    NW_DI:NW750.HDB.ABAPHA
+  web:                                       NW_Webdispatcher:NW750.IND.PD
+  ers:                                       NW_ERS:NW750.HDB.ABAP
+  ers_ha:                                    NW_ERS:NW750.HDB.ABAPHA
+  generic:                                   NW_Users_Create:GENERIC.HDB.PD
+
+materials:
+  dependencies:
+    - name:                                  HANA_2_00_086_v0001ms
+    - name:                                  SWPM10SP44_latest
+    - name:                                  SUM11SP30_latest
+
+  media:
+    
+    # Kernel
+    - name:                                  "Kernel Part I (753) ; OS: Linux on x86_64 64bit ; DB: Database independent"
+      archive:                               SAPEXE_801-80002573.SAR
+      checksum:                              c1efbbd12cb16134720b251fd18cab4fdbc8a0a3ee93b54c2ee41671bc3048fc
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000937192021
+
+    - name:                                  "Kernel Part II (753) ; OS: Linux on x86_64 64bit ; DB: SAP HANA database"
+      archive:                               SAPEXEDB_801-80002572.SAR
+      checksum:                              cea354d096aeca009ffcc81d0830956626fbb0b3c65e7507798256a18318bc5e
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000937602021
+
+    # SAP Host Agent
+    - name:                                  "SAP HOST AGENT 7.21 SP51 ; OS: Linux on x86_64 64bit"
+      archive:                               SAPHOSTAGENT51_51-20009394.SAR
+      checksum:                              7a4dac4d1d57510b8a94d26a442b164f2b8580d01d8429e2427d1f613cd080a5
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000363342021
+
+    # IGS
+    - name:                                  "Installation for SAP IGS integrated in SAP Kernel ; OS: Linux on x86_64"
+      archive:                               igsexe_13-80003187.sar
+      checksum:                              b508b1ff97ec0e3b7f4dd8f57e3840eb547b6326434df677927b8cfd6b4faa12
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000534572021
+
+    - name:                                  "SAP IGS Fonts and Textures"
+      archive:                               igshelper_17-10010245.sar
+      checksum:                              bc405afc4f8221aa1a10a8bc448f8afd9e4e00111100c5544097240c57c99732
+      path:                                  download_basket
+      url:                                   https://softwaredownloads.sap.com/file/0020000000703122018
+
+    # DB Export
+    - name:                                  "NW 7.5 Installation Export"
+      archive:                               51050829_3.ZIP
+      checksum:                              06c3a3cd5d1ad266f61ca202552468501d94cfdc7641ffdadf0a9abad82b648a
+      extract:                               true
+      extractDir:                            CD_EXPORT
+      creates:                               CDLABEL.ASC
+      url:                                   https://softwaredownloads.sap.com/file/0030000000635092016
+
+    # Languages
+    - name:                                  "NW 7.5 Language 1/2"
+      archive:                               51050829_LNG1_part1.exe
+      checksum:                              4fb96950412547ea3a49e9f1488f7fea7fd6c651143113b70b32543f9b166c71
+      url:                                   https://softwaredownloads.sap.com/file/0030000000635132016
+
+    - name:                                  "NW 7.5 Language 2/2"
+      archive:                               51050829_LNG1_part2.rar
+      checksum:                              9fc3fa5a22c120df9d3b6aa04eff39c924dffd8bd633607116f446b46d3b5dd7
+      url:                                   https://softwaredownloads.sap.com/file/0030000000635142016
+
+    # SPAM
+    - name:                                  "SPAM/SAINT Update - Version 752/0089"
+      archive:                               SAPKD75289.SAR
+      checksum:                              29d2d3ab56f67997c6aa77f3ee2c1046848400c093dc8142fd0fd604dee9afd6
+      url:                                   https://softwaredownloads.sap.com/file/0010000001101152024
+      download:                              false
+
+    # Support Packs
+    - name:                                  "ST-PI 740: SP 0002"
+      archive:                               K-74002INSTPI.SAR
+      checksum:                              75459275d69d7d25e6e575dc790a6ffb12a675784922778c646a7896b5ca4d51
+      download:                              true
+      url:                                   https://softwaredownloads.sap.com/file/0010000000057482015
+
+    - name:                                  "ST-PI 740: SP 0003"
+      archive:                               K-74003INSTPI.SAR
+      checksum:                              8a172b86e52884d17abe3ac51072bc26cea93df865906f7a3a16eb7918733b1f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000057492015
+
+    - name:                                  "ST-PI 740: SP 0004"
+      archive:                               K-74004INSTPI.SAR
+      checksum:                              d8bfeb01d995a4c5ed45440e4ea3880bf7101d5efba1c4416a9005745ec4b71e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000059202016
+
+    - name:                                  "ST-PI 740: SP 0005"
+      archive:                               K-74005INSTPI.SAR
+      checksum:                              74da5763244258c103319fe3bd25a461213a33de4fe1093f8aaaf0e0c20ee50b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000841352016
+
+    - name:                                  "ST-PI 740: SP 0006"
+      archive:                               K-74006INSTPI.SAR
+      checksum:                              8954136a9b093769b57d7c5a34bf9983127cd81e9b9d3880c2f5caad3879d2c3
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000012329692017
+
+    - name:                                  "ST-PI 740: SP 0007"
+      archive:                               K-74007INSTPI.SAR
+      checksum:                              a56d4f0a78c9b2cc4893523b9f1ecdcfa9a958254a9841948a857f5d7bd70e40
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019616252017
+
+    - name:                                  "ST-PI 740: SP 0008"
+      archive:                               K-74008INSTPI.SAR
+      checksum:                              ebb16c56e0103036fb2e4e6e6c9a18a55e9562557e929c6163bfde568febe0ac
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000623832018
+
+    - name:                                  "ST-PI 740: SP 0009"
+      archive:                               K-74009INSTPI.SAR
+      checksum:                              77e1cf3db89da6db87bd4af5f625d82454d25ba483dce0c450d9b260f313526d
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002257102018
+
+    - name:                                  "ST-PI 740: SP 0010"
+      archive:                               K-74010INSTPI.SAR
+      checksum:                              ffccb6ea79f034dc39aff3d66ea69b75d468d81002ece6ed98ca9a9419d68d2e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000161692019
+
+    - name:                                  "ST-PI 740: SP 0011"
+      archive:                               K-74011INSTPI.SAR
+      checksum:                              22712d84ee8e098e27941510567bdc00829f40997daae66fdb80c1c5cb720e79
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001051532019
+
+    - name:                                  "ST-PI 740: SP 0012"
+      archive:                               K-74012INSTPI.SAR
+      checksum:                              0f385ce50d6119fca8457aaaea49f7337b5315993d930a16403e04db713f083b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002162182019
+
+    - name:                                  "ST-PI 740: SP 0013"
+      archive:                               K-74013INSTPI.SAR
+      checksum:                              e1270d366de17b67ab2f971195da4fa944509274eea778e664b8050b078d0c45
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000660652020
+
+    - name:                                  "ST-PI 740: SP 0014"
+      archive:                               K-74014INSTPI.SAR
+      checksum:                              f1a9058c623360d576469c51a74e5e649b7055bcac200c5b0f8165801a189048
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001984822020
+
+    - name:                                  "SAP_ABA 750: SP 0001"
+      archive:                               K-75001INSAPABA.SAR
+      checksum:                              1b50801781c20f647deba76b4519d13b5597f9af7322d86e8f2ce452d66eb82e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062252015
+
+    - name:                                  "SAP_BASIS 750: SP 0001"
+      archive:                               K-75001INSAPBASIS.SAR
+      checksum:                              d2f527cf9bfb601234420854d87c05afa05cad1b7903f698214442deb11648a4
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062262015
+
+    - name:                                  "SAP_BW 750: SP 0001"
+      archive:                               K-75001INSAPBW.SAR
+      checksum:                              20f4b1095ed2020e5b6b30508b891800a8bdf20e2ec937d7ab2403cb0864359c
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062272015
+
+    - name:                                  "SAP_GWFND 750: SP 0001"
+      archive:                               K-75001INSAPGWFND.SAR
+      checksum:                              159bf60dd985650960a3e70afaed2cc77d4fe72032f5f7b1fc60a8ecd5361b00
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062282015
+
+    - name:                                  "SAP_ABA 750: SP 0002"
+      archive:                               K-75002INSAPABA.SAR
+      checksum:                              b5e38c9e633e155c1a9be27a879fb6acc1fe4d0136c212b1e5032fda2feb1ce8
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000066952016
+
+    - name:                                  "SAP_BASIS 750: SP 0002"
+      archive:                               K-75002INSAPBASIS.SAR
+      checksum:                              8ecf1aa3ed183120c318972e479c62e341d23f6d4fa1a75c5778a19ce1cee8c8
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062292015
+
+    - name:                                  "SAP_BW 750: SP 0002"
+      archive:                               K-75002INSAPBW.SAR
+      checksum:                              e946616b72274ff6d36b366940ed2528899e95c22d9d377cca302ccf1956f75a
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000066962016
+
+    - name:                                  "SAP_GWFND 750: SP 0002"
+      archive:                               K-75002INSAPGWFND.SAR
+      checksum:                              8f252fcd6657200fe00eb34d98f23a1083b230d95044df4cf167f6f9bed5d066
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000066972016
+
+    - name:                                  "SAP_ABA 750: SP 0003"
+      archive:                               K-75003INSAPABA.SAR
+      checksum:                              bbc60c847887efd2b54cae95e483331fea25358c3378309a9cf8815dc9c0456b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000066982016
+
+    - name:                                  "SAP_BASIS 750: SP 0003"
+      archive:                               K-75003INSAPBASIS.SAR
+      checksum:                              f2e58048b71aea6fdfd81a96ae2f8d74e33368be9f8c4fee22b76a0219e0e10f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000066992016
+
+    - name:                                  "SAP_BW 750: SP 0003"
+      archive:                               K-75003INSAPBW.SAR
+      checksum:                              e4e38232ac12774f4d1c134d747db7312be7437c40094c04fe80c125b6f2e198
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000067002016
+
+    - name:                                  "SAP_GWFND 750: SP 0003"
+      archive:                               K-75003INSAPGWFND.SAR
+      checksum:                              40eb6f189779a1ce1c7fb49ebe769c7bb6623026870da39f7e3a2baa42578446
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000067012016
+
+    - name:                                  "SAP_ABA 750: SP 0004"
+      archive:                               K-75004INSAPABA.SAR
+      checksum:                              68f0ec6cfb93196c5dd0e26b7e0327ecada0ce03bbaa6addb4a496e7f2b2dbfc
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000065922016
+
+    - name:                                  "SAP_BASIS 750: SP 0004"
+      archive:                               K-75004INSAPBASIS.SAR
+      checksum:                              37dc938444a375031135a3b1f017116b7e6f884be1f2065b4f1426fd5ea4315b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000065932016
+
+    - name:                                  "SAP_BW 750: SP 0004"
+      archive:                               K-75004INSAPBW.SAR
+      checksum:                              15a12a74d2fd7a83f291ee7b2c29c18461c809a1ef0e564cf8c37c309db3ad29
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000065942016
+
+    - name:                                  "SAP_GWFND 750: SP 0004"
+      archive:                               K-75004INSAPGWFND.SAR
+      checksum:                              33435ccd1edb1eded3033cf7d528d6c64a4dc45f860567a13492a03a2911d7b7
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000065952016
+
+    - name:                                  "SAP_ABA 750: SP 0005"
+      archive:                               K-75005INSAPABA.SAR
+      checksum:                              c3e4ed3b5fee9f9d0ba047fdaaa714adec8898091cfce6e1481d2aef4807020a
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000508142016
+
+    - name:                                  "SAP_BASIS 750: SP 0005"
+      archive:                               K-75005INSAPBASIS.SAR
+      checksum:                              311ee0580c82b0d2f0c4166fc6bf07d26baeac168104265f9a1b6baa7be5f21b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000508152016
+
+    - name:                                  "SAP_BW 750: SP 0005"
+      archive:                               K-75005INSAPBW.SAR
+      checksum:                              c43d09d789fe457ea3126f07010925ddac1d82fd869fe325cf4de904c26d6f18
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000508182016
+
+    - name:                                  "SAP_GWFND 750: SP 0005"
+      archive:                               K-75005INSAPGWFND.SAR
+      checksum:                              73d227073eaf7e6e30c62f32806b9bdca310569e22623ad06a78d7a8f060de6a
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000508162016
+
+    - name:                                  "SAP_ABA 750: SP 0006"
+      archive:                               K-75006INSAPABA.SAR
+      checksum:                              991a9246a2a8413ffb994d3358820f5e78fa8ef09ff2c051c36c7f021865506e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000869062016
+
+    - name:                                  "SAP_BASIS 750: SP 0006"
+      archive:                               K-75006INSAPBASIS.SAR
+      checksum:                              db24470627bf6ee419271ec5a3c1fa52a4fbad82da6edde6641f89fa5b28bf31
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000869072016
+
+    - name:                                  "SAP_BW 750: SP 0006"
+      archive:                               K-75006INSAPBW.SAR
+      checksum:                              4c6b9737da4571223706d7b7cfa99e296618e5c00de1301bf51642f12673a360
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000869102016
+
+    - name:                                  "SAP_GWFND 750: SP 0006"
+      archive:                               K-75006INSAPGWFND.SAR
+      checksum:                              4a99c0e4c09999e99d3223c4541911dba621f1a1f692d1507af130fb46e68ec7
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000869082016
+
+    - name:                                  "SAP_ABA 750: SP 0007"
+      archive:                               K-75007INSAPABA.SAR
+      checksum:                              665f1d8bc5b65b3d3135068960d17e80ac5c5fb6dde0de95fa122ab16c3e1c32
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000004963902017
+
+    - name:                                  "SAP_BASIS 750: SP 0007"
+      archive:                               K-75007INSAPBASIS.SAR
+      checksum:                              fec21ece3443fb7ad60cb618c72fed8771ac34ce84cf0ae350d309e874877849
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000004963522017
+
+    - name:                                  "SAP_BW 750: SP 0007"
+      archive:                               K-75007INSAPBW.SAR
+      checksum:                              9fd4d57353ea5dfc494ec37fe598e9ae54a4bd651d123cc663f5799169c42ba6
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000004963602017
+
+    - name:                                  "SAP_GWFND 750: SP 0007"
+      archive:                               K-75007INSAPGWFND.SAR
+      checksum:                              76e2d8de224c38d05ea1b8ad8be4c3f824424749cfba22ea8105787969069380
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000004966192017
+
+    - name:                                  "SAP_ABA 750: SP 0008"
+      archive:                               K-75008INSAPABA.SAR
+      checksum:                              03f17ea0b704f1f54d5ee1fc618129ebf3807132314079b38bc95da52468f3a6
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000018731672017
+
+    - name:                                  "SAP_BASIS 750: SP 0008"
+      archive:                               K-75008INSAPBASIS.SAR
+      checksum:                              dda3bb3d9e4f42720839aee897849576284c97d43e308aa4606956ef0ea66cb1
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000018731682017
+
+    - name:                                  "SAP_BW 750: SP 0008"
+      archive:                               K-75008INSAPBW.SAR
+      checksum:                              1983c80385dc6df351ff1204949b5fa3bb67c92acc531f4624e4b19d2830c6c4
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000018731712017
+
+    - name:                                  "SAP_GWFND 750: SP 0008"
+      archive:                               K-75008INSAPGWFND.SAR
+      checksum:                              754770f49985964d3a2d170a454ad1e0430f4bdbb894e5bbef53edd4218f761f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000018731692017
+
+    - name:                                  "SAP_ABA 750: SP 0009"
+      archive:                               K-75009INSAPABA.SAR
+      checksum:                              622369b042897d81583901e3038b894e9021f68b6ad86a00c453f2300319e90f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019379412017
+
+    - name:                                  "SAP_BASIS 750: SP 0009"
+      archive:                               K-75009INSAPBASIS.SAR
+      checksum:                              42ffc3dd546144401bb2793c13f98256f40a9c3fc721d4211a772af9fc6a1793
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019379502017
+
+    - name:                                  "SAP_BW 750: SP 0009"
+      archive:                               K-75009INSAPBW.SAR
+      checksum:                              81e37d566002e3cde1ea3b00057aa68b9c2f101dcbd73be7def4aa5cff98265f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019379582017
+
+    - name:                                  "SAP_GWFND 750: SP 0009"
+      archive:                               K-75009INSAPGWFND.SAR
+      checksum:                              960a9a5419c9ce565cd7ed46b83228c5b9d76b475b358a6ed4660999f611b6dc
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019379602017
+
+    - name:                                  "SAP_ABA 750: SP 0010"
+      archive:                               K-75010INSAPABA.SAR
+      checksum:                              155621b9be7b52c230da299656759e304aece0e80a7435d940fa31bcac39daff
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019960222017
+
+    - name:                                  "SAP_BASIS 750: SP 0010"
+      archive:                               K-75010INSAPBASIS.SAR
+      checksum:                              a8242bee46bd75ed423834d7ffc36313a9e24bcb892a23ec176b9d6b3b274441
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019960242017
+
+    - name:                                  "SAP_BW 750: SP 0010"
+      archive:                               K-75010INSAPBW.SAR
+      checksum:                              ccd7842cdada799a25f19d73cb5e22db5ac95b01ab9bc7120f0a3aef77bc1563
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019960282017
+
+    - name:                                  "SAP_GWFND 750: SP 0010"
+      archive:                               K-75010INSAPGWFND.SAR
+      checksum:                              4bdec2cc691bad66846109e890f26e1c64c6a2cb69cb90f189ea5240522bf19a
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000019960292017
+
+    - name:                                  "SAP_ABA 750: SP 0011"
+      archive:                               K-75011INSAPABA.SAR
+      checksum:                              17472809180b861bbcf6a5c19edcaa3a53b59998245a74c6241487de9cceeacd
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000174662018
+
+    - name:                                  "SAP_BASIS 750: SP 0011"
+      archive:                               K-75011INSAPBASIS.SAR
+      checksum:                              b3a3d11613f1c53a63719980024baaa136d479dd4151c25a094f975172290a72
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000174692018
+
+    - name:                                  "SAP_BW 750: SP 0011"
+      archive:                               K-75011INSAPBW.SAR
+      checksum:                              b2c97e59610ee10e16e9e118ba44e5b2dc4faaffd13d1792b82b36f99b2e16d7
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000174712018
+
+    - name:                                  "SAP_GWFND 750: SP 0011"
+      archive:                               K-75011INSAPGWFND.SAR
+      checksum:                              3ed038f8b5dc1db4861a58c54bb22e8e10de023258fd570dc1e2283fd7840fcc
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000174722018
+
+    - name:                                  "SAP_ABA 750: SP 0012"
+      archive:                               K-75012INSAPABA.SAR
+      checksum:                              90ed4f8ef812a40b79de48e660c9d237e7d4fdcbc43678c7264d6eb69b4ae149
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000940002018
+
+    - name:                                  "SAP_BASIS 750: SP 0012"
+      archive:                               K-75012INSAPBASIS.SAR
+      checksum:                              c74299c8dcb6cbf7dd4d3db268f7bcf1daa7cb537e6365cc5f0e6961f0fc16a0
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000940032018
+
+    - name:                                  "SAP_BW 750: SP 0012"
+      archive:                               K-75012INSAPBW.SAR
+      checksum:                              291f1be5883f66cbd7d60850f8534ebf510e1a8283ed229377db5f954f47f2e4
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000940052018
+
+    - name:                                  "SAP_GWFND 750: SP 0012"
+      archive:                               K-75012INSAPGWFND.SAR
+      checksum:                              905f5380cc077e8ce1ff436513c6ffef23ea5a2f143dbc4169f0822378c93897
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000940072018
+
+    - name:                                  "SAP_ABA 750: SP 0013"
+      archive:                               K-75013INSAPABA.SAR
+      checksum:                              fd3ac7e49f0a4cc20ac2dc36dfabf85844f74ba55857d86aa22e6599fecf0072
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001555712018
+
+    - name:                                  "SAP_BASIS 750: SP 0013"
+      archive:                               K-75013INSAPBASIS.SAR
+      checksum:                              62aaa6751725d27aaf80a100b69e6ce98e0b2667a4e06fb03510415b1492f269
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001555662018
+
+    - name:                                  "SAP_BW 750: SP 0013"
+      archive:                               K-75013INSAPBW.SAR
+      checksum:                              5ac3b3c77c82c5634a121d26b131a5bbe90c71360622d520a9bea1175ab4dac5
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001555672018
+
+    - name:                                  "SAP_GWFND 750: SP 0013"
+      archive:                               K-75013INSAPGWFND.SAR
+      checksum:                              4fc2e24fbb01b139abb1060135e925c10228d2bcd5c83f18afa133f8aeaf2348
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001555682018
+
+    - name:                                  "SAP_ABA 750: SP 0014"
+      archive:                               K-75014INSAPABA.SAR
+      checksum:                              03b4931e4045d5ce26ee52de42ac8fe3365a17849a44cb505964faa1f58636c5
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000002622019
+
+    - name:                                  "SAP_BASIS 750: SP 0014"
+      archive:                               K-75014INSAPBASIS.SAR
+      checksum:                              00048ed9d0da51977d46a64370f351dba7bbaaaab7ec1a5dc267dfcb24402e99
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000134642019
+
+    - name:                                  "SAP_BW 750: SP 0014"
+      archive:                               K-75014INSAPBW.SAR
+      checksum:                              a95c1b4beea0a413122264a598d97d611982b8c853f91f35c6c6eeda5807e708
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000134652019
+
+    - name:                                  "SAP_GWFND 750: SP 0014"
+      archive:                               K-75014INSAPGWFND.SAR
+      checksum:                              8343cd7c77d781492c3e3b0a3137d3643f4e95b9547315fde8ea9c402aa25068
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000134662019
+
+    - name:                                  "SAP_ABA 750: SP 0015"
+      archive:                               K-75015INSAPABA.SAR
+      checksum:                              409391308364b6f6b8eae68b5f5213d6a8e876894076022801d5b6c941bc408e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000794332019
+
+    - name:                                  "SAP_BASIS 750: SP 0015"
+      archive:                               K-75015INSAPBASIS.SAR
+      checksum:                              b51f7a2858f185066ef2d16f6a0868190d02cc698b64681f2a6d72e80da038bb
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000794362019
+
+    - name:                                  "SAP_BW 750: SP 0015"
+      archive:                               K-75015INSAPBW.SAR
+      checksum:                              a56c69c54c5512883c3e700f5a28b79662687afa2376fe644a8c878a41a3bb26
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000794372019
+
+    - name:                                  "SAP_GWFND 750: SP 0015"
+      archive:                               K-75015INSAPGWFND.SAR
+      checksum:                              76066cf2fcb889932abff5f8ba882a2b764b902fccc535f0596f2adddf862c66
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000794382019
+
+    - name:                                  "SAP_ABA 750: SP 0016"
+      archive:                               K-75016INSAPABA.SAR
+      checksum:                              8a74ee1a696075f1c7b582840a58bc47f5743c54514d71eff4be323b0934f04d
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001417012019
+
+    - name:                                  "SAP_BASIS 750: SP 0016"
+      archive:                               K-75016INSAPBASIS.SAR
+      checksum:                              27451e2d088f5255fe7151bcddf96ca57b6f8ee1ac0304454664b3fc6b052af4
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001417142019
+
+    - name:                                  "SAP_BW 750: SP 0016"
+      archive:                               K-75016INSAPBW.SAR
+      checksum:                              51c3d7923a8aeba09c045ea60e94886ef33d474a29f2309c1accb68b46fd9d3d
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001428782019
+
+    - name:                                  "SAP_GWFND 750: SP 0016"
+      archive:                               K-75016INSAPGWFND.SAR
+      checksum:                              972b8d655dd356e9c7caacf73bb67a08567876425f117b60c16611f4b078e680
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001417282019
+
+    - name:                                  "SAP_ABA 750: SP 0017"
+      archive:                               K-75017INSAPABA.SAR
+      checksum:                              7c54b23004e3ec6a1610bcef8a352469d60f1ceec30ceeb74b09d50d63c52365
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002325032019
+
+    - name:                                  "SAP_BASIS 750: SP 0017"
+      archive:                               K-75017INSAPBASIS.SAR
+      checksum:                              824c55e2b57f3fb9ecb350b13a193498977d80fb081ebd9a559043098f127de8
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002325042019
+
+    - name:                                  "SAP_BW 750: SP 0017"
+      archive:                               K-75017INSAPBW.SAR
+      checksum:                              ab00f06c3bcb6cad9c77f2181b2319856735164775229b0d5a6ac181f15aec7c
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002325072019
+
+    - name:                                  "SAP_GWFND 750: SP 0017"
+      archive:                               K-75017INSAPGWFND.SAR
+      checksum:                              4f07f32a483faf7c34f76421d249ca6e1e4242c564bb0c9b9fc7a60c4d9f32c9
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002325082019
+
+    - name:                                  "SAP_ABA 750: SP 0018"
+      archive:                               K-75018INSAPABA.SAR
+      checksum:                              37667b5d2b73269876d313c065f48fb223ae59a9af8158f467907164be277538
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000673222020
+
+    - name:                                  "SAP_BASIS 750: SP 0018"
+      archive:                               K-75018INSAPBASIS.SAR
+      checksum:                              c305fa265bd806c0f8c0ccb84a5ffd8192d4a0950fe771ede349101a0773f42c
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000673242020
+
+    - name:                                  "SAP_BW 750: SP 0018"
+      archive:                               K-75018INSAPBW.SAR
+      checksum:                              e445c62a642e0b6e60adb94f8f05d396150d7fc9e803a239e4cff4aeba345b9f
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000673272020
+
+    - name:                                  "SAP_GWFND 750: SP 0018"
+      archive:                               K-75018INSAPGWFND.SAR
+      checksum:                              1e247885d4eeff92d257ed7c7ed782955c3e3fed54f5714870d73edfd4583c81
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000673282020
+
+    - name:                                  "SAP_ABA 750: SP 0019"
+      archive:                               K-75019INSAPABA.SAR
+      checksum:                              84882d34314633b37852fe1438360c25ee08641ffd47a49bb95e030ff1e0e0c9
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001250502020
+
+    - name:                                  "SAP_BASIS 750: SP 0019"
+      archive:                               K-75019INSAPBASIS.SAR
+      checksum:                              2ccda0eb02ba2383b02e7b8bd19491d1ac9285338afaf14f8dd0b88f7a8dcaaa
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001250512020
+
+    - name:                                  "SAP_BW 750: SP 0019"
+      archive:                               K-75019INSAPBW.SAR
+      checksum:                              2b9611219d6125e030cbdad379aefe20ebfc31feab2cb84d61f3ebcd2d34b295
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001250522020
+
+    - name:                                  "SAP_GWFND 750: SP 0019"
+      archive:                               K-75019INSAPGWFND.SAR
+      checksum:                              ebbe7db7ad575eab8bafa42411505855e3ebe1c910f889470d862a89c24ea542
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001250532020
+
+    - name:                                  "SAP_ABA 750: SP 0020"
+      archive:                               K-75020INSAPABA.SAR
+      checksum:                              53671996cfd72c4f6b014de83c353eb209ed0d701f0475e270030be224c53f72
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000074672021
+
+    - name:                                  "SAP_BASIS 750: SP 0020"
+      archive:                               K-75020INSAPBASIS.SAR
+      checksum:                              0d4937e5c8d6c4a568ee91fff41dd8051a0d4c6965f6dab7bbcf9c3e29fbfbad
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000074682021
+
+    - name:                                  "SAP_BW 750: SP 0020"
+      archive:                               K-75020INSAPBW.SAR
+      checksum:                              3794a63e7cdaae25b44e0eb92cb7a221be000d776eba2e76082fb6ef52085767
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000074692021
+
+    - name:                                  "SAP_GWFND 750: SP 0020"
+      archive:                               K-75020INSAPGWFND.SAR
+      checksum:                              eaa939f5fdb1714066d19f7fde35facaec272886b888e57fb6ff928335d6e63c
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000074702021
+
+    - name:                                  "SAP_UI 754: SP 0001"
+      archive:                               K-75401INSAPUI.SAR
+      checksum:                              212fc7d928ced7bd9a9c1e587f65457a6e40bb2bb49527ea88834e4f32b3639e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001661402019
+
+    - name:                                  "SAP_UI 754: SP 0002"
+      archive:                               K-75402INSAPUI.SAR
+      checksum:                              3a4bcfd61b3015083e5e28a6db294c9c09277778b49d0259debebbf63443996d
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000002197612019
+
+    - name:                                  "SAP_UI 754: SP 0003"
+      archive:                               K-75403INSAPUI.SAR
+      checksum:                              0a7640a5a2174b0dee45810466473932265f67bf6b0aa6e355930315513379c3
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000380882020
+
+    - name:                                  "SAP_UI 754: SP 0004"
+      archive:                               K-75404INSAPUI.SAR
+      checksum:                              260318324bf29dff72a59cac8ce4d607803ba27abfcfd30e999b9b0bc373bb9c
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000876572020
+
+    - name:                                  "SAP_UI 754: SP 0005"
+      archive:                               K-75405INSAPUI.SAR
+      checksum:                              a493ff19b33d555960d10e53657f5803a21bdf1c7ca3b91345da24afa5671e6e
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000001523772020
+
+    - name:                                  "SAP_UI 754: SP 0006"
+      archive:                               K-75406INSAPUI.SAR
+      checksum:                              9ebca229381c5b56aef1641351d0dddde7e8ca547a71ff6efc787fa3f0180c1b
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000325802021
+
+    - name:                                  "SAP_UI 754 Update: Meta-Commandfile"
+      archive:                               K-754BHINSAPUI.SAR
+      checksum:                              21c5ef4f4e7583a2a917dc66429590d31cdcf4b9a26cb8b3f4b6ad25a7041c7d
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000183702019
+
+    - name:                                  "Attribute Change Package 06 for SAP_BASIS 750"
+      archive:                               SAP_BASIS750.SAR
+      checksum:                              05025bb130810c2d80d0cea31f76ef1690c3d61a648644bcfb8664178d990a76
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000062582015
+
+    - name:                                  "Attribute Change Package 07 for SAP_BW 750"
+      archive:                               SAP_BW750.SAR
+      checksum:                              a8b0050fb30386db90acd983cd4ecc53fc68ef58bfbf1ac4dbb0a5428fcaae40
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000067382016
+
+    - name:                                  "Attribute Change Package 03 for SAP_GWFND 750"
+      archive:                               SAP_GWFND750.SAR
+      checksum:                              57d6dfed87618710519268c9147c381d551ac6aec4fb3d33486bc62e0314c5a5
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000067402016
+
+    - name:                                  "Attribute Change Package 07 for SAP_UI 754"
+      archive:                               SAP_UI754.SAR
+      checksum:                              cc0d69286eaec4bd21510984b06f02368df2a84c34e5080c72305bae1498dae4
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000031692020
+
+    - name:                                  "Attribute Change Package 56 for ST-PI 740"
+      archive:                               ST-PI740.SAR
+      checksum:                              603e83e417638508f7bfda9eed3e2f13bf7853e26439e5ff494ce9d51a930da5
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000297212015
+
+# other components
+
+    - name:                                  "SAPCAR"
+      archive:                               SAPCAR_1115-70006178.EXE
+      checksum:                              765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5
+      filename:                              SAPCAR
+      permissions:                           '0755'
+      url:                                   https://softwaredownloads.sap.com/file/0020000000098642022

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-app-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-app-inifile-param.j2
@@ -1,0 +1,46 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+############################################################################################################################################################################################################
+#                                                                                                                                                                                                          #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Additional SAP System Instances > Additional Application Server Instance', product id 'NW_DI:NW750.HDB.PD' #                                                                            #
+#                                                                                                                                                                                                          #
+############################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPABAP1
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_CI_Instance.ascsVirtualHostname                                    = {{ sap_scs_hostname }}
+NW_CI_Instance.ciInstanceNumber                                       = {{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciMSPort                                               = 36{{ scs_instance_number }}
+NW_CI_Instance.ciVirtualHostname                                      = {{ sap_ciVirtualHostname }}
+NW_CI_Instance.scsVirtualHostname                                     = {{ sap_scs_hostname }}
+NW_CI_Instance_ABAP_Reports.executeReportsForDepooling                = true
+
+NW_DDIC_Password.needDDICPasswords                                    = false
+NW_HDB_getDBInfo.instanceNumber                                       = {{ db_instance_number }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+storageBasedCopy.hdb.instanceNumber                                   = {{ db_instance_number }}
+storageBasedCopy.hdb.systemPassword                                   = {{ main_password }}

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-dbload-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-dbload-inifile-param.j2
@@ -1,0 +1,50 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+##########################################################################################################################################################################################
+#                                                                                                                                                                                        #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server ABAP                                                                                   #
+#                       > Distributed System > Database Instance', product id 'NW_ABAP_DB:NW750.HDB.ABAP'                                                                                #
+#                                                                                                                                                                                        #
+##########################################################################################################################################################################################
+
+# Location of Export CD
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+hanadb.landscape.reorg.useCheckProcedureFile                          = DONOTUSEFILE
+hanadb.landscape.reorg.useParameterFile                               = DONOTUSEFILE
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPABAP1
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+HDB_Software_Dialogs.useMediaCD                                       = true
+NW_ABAP_Import_Dialog.dbCodepage                                      = 4103
+NW_ABAP_Import_Dialog.migmonJobNum                                    = 12
+NW_ABAP_Import_Dialog.migmonLoadArgs                                  = -c 100000 -rowstorelist /tmp/sapinst_instdir/NW750/HDB/INSTALL/HA/ABAP/DB/rowstorelist.txt
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_getLoadType.loadType                                               = SAP
+NW_getLoadType.loadType                                               = SAP
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+NW_GetSidNoProfiles.sapdrive                                          = undefined
+NW_GetSidNoProfiles.sid                                               = {{ sap_sid | upper }}
+NW_HDB_DB.abapSchemaName                                              = SAPABAP1
+NW_HDB_DB.abapSchemaPassword                                          = {{ main_password }}
+NW_HDB_DBClient.clientPathStrategy                                    = SAPCPE
+NW_HDB_getDBInfo.dbhost                                               = {{ sap_db_hostname }}
+NW_HDB_getDBInfo.dbsid                                                = {{ db_sid | upper }}
+NW_HDB_getDBInfo.instanceNumber                                       = {{ db_instance_number }}
+NW_HDB_getDBInfo.systemDbPassword                                     = {{ main_password }}
+NW_HDB_getDBInfo.systemid                                             = {{ db_sid | upper }}
+NW_HDB_getDBInfo.systemPassword                                       = {{ main_password }}
+NW_HDB_getDBInfo.usingSSL                                             = true
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+NW_readProfileDir.profilesAvailable                                   = false
+NW_Recovery_Install_HDB.extractLocation                               = {{ hana_backup_path }}/{{ db_sid | upper }}/HDB{{ db_instance_number }}/backup/data/DB_{{ db_sid | upper }}{{ db_instance_number }}
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+SAPINST.CD.PACKAGE.CD1                                               = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                               = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                               = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                               = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                               = {{ sap_cd_package_cd5 }}
+SAPINST.CD.PACKAGE.HDBCLIENT                                         = {{ sap_cd_package_hdbclient }}

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-ers-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-ers-inifile-param.j2
@@ -1,0 +1,34 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+###############################################################################################################################################################################################################
+#                                                                                                                                                                                                              #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server ABAP > High-Availability System > Enqueue Replication Server Instance', product id 'NW_ERS:NW750.HDB.ABAPHA' #
+#                                                                                                                                                                                                              #
+################################################################################################################################################################################################################
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                               = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+hostAgent.sapAdmPassword                                             = {{ main_password }}
+
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}
+
+nw_instance_ers.ersInstanceNumber                                    = {{ ers_instance_number }}
+nw_instance_ers.ersVirtualHostname                                   = {{ ers_virtual_hostname }}
+
+NW_adaptProfile.skipSecurityProfileSettings                          = true
+NW_readProfileDir.profileDir                                         = /sapmnt/{{ sap_sid | upper }}/profile

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-generic-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-generic-inifile-param.j2
@@ -1,0 +1,32 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+#   Creation of user for ERS and SCS issues during HA installation - 14-03-2022
+
+########################################################################################################################################################################################################
+#                                                                                                                                                                                                      #
+# Installation service 'Generic Options > SAP HANA Database > Preparations > Operating System Users and Groups', product id 'NW_Users_Create:GENERIC.HDB.PD'                                           #
+#                                                                                                                                                                                                      #
+########################################################################################################################################################################################################
+
+
+NW_Users_Create.dbsid                                                 = {{ sap_sid | upper }}
+
+# Specify whether you are preparing for an SAP sytem based on AS ABAP.
+NW_Users_Create.hasABAP                                               = true
+
+# Specify whether database users are to be installed.
+NW_Users_Create.installDBUsers                                        = false
+
+# SAP system ID
+NW_Users_Create.sid                                                   = {{ sap_sid | upper }}
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+# Password for the 'sapadm' user of the SAP Host Agent
+hostAgent.sapAdmPassword =  {{ main_password }}
+
+
+

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-pas-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-pas-inifile-param.j2
@@ -1,0 +1,47 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+############################################################################################################################################################################################################
+#                                                                                                                                                                                                          #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server ABAP                                                                                                     #
+#                       > Distributed System > Primary Application Server Instance', product id 'NW_ABAP_CI:NW750.HDB.ABAP'                                                                                #
+#                                                                                                                                                                                                          #
+############################################################################################################################################################################################################
+
+# Location of Export CD
+SAPINST.CD.PACKAGE.HDBCLIENT                                          = {{ sap_cd_package_hdbclient }}
+SAPINST.CD.PACKAGE.CD1                                                = {{ sap_cd_package_cd1 }}
+SAPINST.CD.PACKAGE.CD2                                                = {{ sap_cd_package_cd2 }}
+SAPINST.CD.PACKAGE.CD3                                                = {{ sap_cd_package_cd3 }}
+SAPINST.CD.PACKAGE.CD4                                                = {{ sap_cd_package_cd4 }}
+SAPINST.CD.PACKAGE.CD5                                                = {{ sap_cd_package_cd5 }}
+
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+HDB_Schema_Check_Dialogs.schemaName                                   = SAPABAP1
+HDB_Schema_Check_Dialogs.schemaPassword                               = {{ main_password }}
+
+NW_CI_Instance.ascsVirtualHostname                                    = {{ sap_scs_hostname }}
+NW_CI_Instance.ciInstanceNumber                                       = {{ sap_ciInstanceNumber }}
+NW_CI_Instance.ciMSPort                                               = 36{{ scs_instance_number }}
+NW_CI_Instance.ciVirtualHostname                                      = {{ sap_ciVirtualHostname }}
+NW_CI_Instance.scsVirtualHostname                                     = {{ sap_scs_hostname }}
+NW_CI_Instance_ABAP_Reports.executeReportsForDepooling                = true
+
+NW_DDIC_Password.needDDICPasswords                                    = false
+NW_HDB_getDBInfo.instanceNumber                                       = {{ db_instance_number }}
+
+NW_checkMsgServer.abapMSPort                                          = 36{{ scs_instance_number }}
+NW_getLoadType.loadType                                               = SAP
+NW_readProfileDir.profileDir                                          = {{ sap_profile_dir }}
+
+storageBasedCopy.hdb.instanceNumber                                   = {{ db_instance_number }}
+storageBasedCopy.hdb.systemPassword                                   = {{ main_password }}

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-scs-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-scs-inifile-param.j2
@@ -1,0 +1,27 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################
+#                                                                                                                                                                                      #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server ABAP                                                                                 #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:NW750.HDB.ABAP'                                                                                #
+#                                                                                                                                                                                      #
+########################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-scsha-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-scsha-inifile-param.j2
@@ -1,0 +1,27 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+########################################################################################################################################################################################
+#                                                                                                                                                                                      #
+# Installation service 'SAP NetWeaver 7.5 > SAP HANA Database > Installation > Application Server ABAP                                                                                 #
+#                       > Distributed System > ASCS Instance', product id 'NW_ABAP_ASCS:NW750.HDB.ABAP'                                                                                #
+#                                                                                                                                                                                      #
+########################################################################################################################################################################################
+
+
+archives.downloadBasket                                              = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                    = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                    = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                    = {{ sidadm_uid }}
+
+NW_Delete_Sapinst_Users.removeUsers                                  = true
+NW_GetMasterPassword.masterPwd                                       = {{ main_password }}
+NW_GetSidNoProfiles.sid                                              = {{ sap_sid }}
+
+NW_SCS_Instance.ascsInstallGateway                                   = true
+NW_SCS_Instance.ascsInstallWebDispatcher                             = false
+NW_SCS_Instance.instanceNumber                                       = {{ scs_instance_number }}
+NW_SCS_Instance.scsVirtualHostname                                   = {{ sap_scs_hostname }}
+
+NW_getFQDN.FQDN                                                      = {{ sap_fqdn }}

--- a/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-web-inifile-param.j2
+++ b/SAP/NW750SPS20_v0008ms/templates/NW750SPS20_v0007ms-web-inifile-param.j2
@@ -1,0 +1,33 @@
+#   2482103 - Installation with SWPM in unattended mode using parameter input file fails
+#   2393060 - SAPinst Framework 749 Central Note
+
+archives.downloadBasket                                               = {{ target_media_location }}/download_basket
+
+nwUsers.sapadmUID                                                     = {{ sapadm_uid }}
+nwUsers.sapsysGID                                                     = {{ sapsys_gid }}
+nwUsers.sidAdmUID                                                     = {{ sidadm_uid }}
+nwUsers.sidadmPassword                                                = {{ main_password }}
+
+NW_Delete_Sapinst_Users.removeUsers                                   = true
+NW_GetMasterPassword.masterPwd                                        = {{ main_password }}
+
+NW_adaptProfile.skipSecurityProfileSettings                           = true
+NW_getFQDN.FQDN                                                       = {{ sap_fqdn }}
+
+NW_GetSidNoProfiles.sid                                               = {{ web_sid | upper }}
+NW_webdispatcher_Instance.backEndSID                                  = {{ sap_sid | upper }}
+
+NW_Webdispatcher_Instance.wdInstanceNumber                            = {{ web_instance_number }}
+NW_webdispatcher_Instance.activateICF                                 = false
+
+NW_webdispatcher_Instance.msHTTPPort                                  = 81{{ sap_ciInstanceNumber }}
+NW_webdispatcher_Instance.msHost                                      = {{ sap_scs_hostname }}
+
+NW_webdispatcher_Instance.rfcHost                                     = {{ sap_scs_hostname }}
+NW_webdispatcher_Instance.wdVirtualHostname                           = {{ sap_webVirtualHostname }}
+
+NW_webdispatcher_Instance.scenarioSize                                = 500
+NW_webdispatcher_Instance.wdHTTPPort                                  = 80{{ web_instance_number }}
+NW_webdispatcher_Instance.wdHTTPSPort                                 = 443{{ web_instance_number }}
+
+NW_System.installSAPHostAgent                                         = {{ sap_installSAPHostAgent }}

--- a/SAP/S42023SPS00_v0007ms/S42023SPS00_v0007ms.yaml
+++ b/SAP/S42023SPS00_v0007ms/S42023SPS00_v0007ms.yaml
@@ -1,7 +1,7 @@
 ---
 
 name:                                        "SAP S/4HANA 2023 ISS 00"
-filename:                                    "S42023SPS00_v0001ms"
+filename:                                    "S42023SPS00_v0007ms"
 target:                                      "S/4 HANA 2023 ISS 00"
 version:                                     5
 platform:                                    'HANA'

--- a/SAP/S42023SPS00_v0007ms/S42023SPS00_v0007ms.yaml
+++ b/SAP/S42023SPS00_v0007ms/S42023SPS00_v0007ms.yaml
@@ -1,0 +1,631 @@
+---
+
+name:                                        "SAP S/4HANA 2023 ISS 00"
+filename:                                    "S42023SPS00_v0001ms"
+target:                                      "S/4 HANA 2023 ISS 00"
+version:                                     5
+platform:                                    'HANA'
+InstanceType:                                'ABAP'
+
+
+defaults:
+  target_location:                           "{{ target_media_location }}/download_basket"
+
+product_ids:
+  scs:                                       "NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAP"
+  scs_ha:                                    "NW_ABAP_ASCS:S4HANA2023.CORE.HDB.ABAPHA"
+  dbl:                                       "NW_ABAP_DB:S4HANA2023.CORE.HDB.ABAP"
+  pas:                                       "NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAP"
+  pas_ha:                                    "NW_ABAP_CI:S4HANA2023.CORE.HDB.ABAPHA"
+  app:                                       "NW_DI:S4HANA2023.CORE.HDB.PD"
+  app_ha:                                    "NW_DI:S4HANA2023.CORE.HDB.ABAPHA"
+  web:                                       "NW_Webdispatcher:NW750.IND.PD"
+  ers:                                       "NW_ERS:S4HANA2022.CORE.HDB.ABAP"
+  ers_ha:                                    "NW_ERS:S4HANA2022.CORE.HDB.ABAPHA"
+  generic:                                   "NW_Users_Create:GENERIC.HDB.PD"
+
+
+materials:
+  dependencies:
+    - name:                                  "HANA_2_00_086_v0001ms"
+    - name:                                  "SWPM20SP21_latest"
+    - name:                                  "SUM20SP23_latest"
+
+  media:
+     # SAPCAR 7.22
+    - name:                                  "SAPCAR 7.22; OS: Linux on x86_64 64bit"
+      archive:                               SAPCAR_1115-70006178.EXE
+      checksum:                              765412436934362cc5497e3d659fbb78be91093a091c11ec4fbe84dfb415a0e5
+      filename:                              SAPCAR
+      permissions:                           '0755'
+      url:                                   https://softwaredownloads.sap.com/file/0020000000098642022
+
+    # kernel components
+
+    - name:                                  "Kernel Part II (793)"
+      archive:                               SAPEXEDB_51-70007806.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0020000001134862023
+      path:                                  download_basket
+      checksum:                              6866c46a6bb13a09dae82d8ce160fe8d73d4bcdff0da00e5a52cfffda7af7891
+
+    - name:                                  "Kernel Part I (793)"
+      archive:                               SAPEXE_51-70007807.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0020000001133782023
+      path:                                  download_basket
+      checksum:                              27a6c126cd2a15e0fdf3973cc914805d2f0dc738ff3a42c7220ea4fb2fa7590d
+
+    - name:                                  "SP12 Patch8 for UMML4HANA 1"
+      archive:                               HANAUMML12_8-70001054.ZIP
+      url:                                   https://softwaredownloads.sap.com/file/0020000000146922024
+      path:                                  download_basket
+      checksum:                              ef60422cab183f76cae3c3296f0e9d08c9f692ff44542d23e94e0dedd50fbae4
+
+    - name:                                  "SAP HOST AGENT 7.22 SP61"
+      archive:                               SAPHOSTAGENT61_61-80004822.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0020000000867792023
+      path:                                  download_basket
+      checksum:                              280c13ca76d3b2fb1aba5cccdff9b9e3ae7988f6ca5f2553563fd2360dc8f688
+
+    - name:                                  "Predi. Analy. APL 2203 for SAP HANA 2.0 SPS03 and beyond"
+      archive:                               SAPPAAPL4_2203_2-80004547.ZIP
+      url:                                   https://softwaredownloads.sap.com/file/0020000000163142022
+      path:                                  download_basket
+      checksum:                              c5d5d750d26b343edd8582f9f683cb25978e01c86d8da8493b7f4f4023956c73
+
+    - name:                                  "Installation for SAP IGS integrated in SAP Kernel Support Package 7.81"
+      archive:                               igsexe_4-70005417.sar
+      url:                                   https://softwaredownloads.sap.com/file/0020000001329472023
+      path:                                  download_basket
+      checksum:                              237b86dc21f3d6ff0161a57aaa3917c5a11e3377330edbe73ceab78350085b23
+
+    - name:                                  "SAP IGS Fonts and Textures"
+      archive:                               igshelper_17-10010245.sar
+      url:                                   https://softwaredownloads.sap.com/file/0020000000703122018
+      path:                                  download_basket
+      checksum:                              bc405afc4f8221aa1a10a8bc448f8afd9e4e00111100c5544097240c57c99732
+
+    # db export components
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_1.zip"
+      archive:                               S4CORE108_INST_EXPORT_1.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164272023
+      path:                                  download_basket
+      checksum:                              536bc224ce3960b911787af97f360664832b35f17b33407e3b5b6495235b87ae
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_10.zip"
+      archive:                               S4CORE108_INST_EXPORT_10.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164282023
+      path:                                  download_basket
+      checksum:                              961d24af7670cfd0493e8aa1a672d3ea4e4add01b3561111f3ac09a158bdaeb8
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_11.zip"
+      archive:                               S4CORE108_INST_EXPORT_11.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164292023
+      path:                                  download_basket
+      checksum:                              9d433bd3cca83ffe5f7c366fd28a41794f1b8e133e9523900e20f4ef705dab34
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_12.zip"
+      archive:                               S4CORE108_INST_EXPORT_12.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164302023
+      path:                                  download_basket
+      checksum:                              ad451d8b28b752ed24fe555f9b741d7db568d7b0d1c72b59ad4cd9b1bb37f719
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_13.zip"
+      archive:                               S4CORE108_INST_EXPORT_13.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164322023
+      path:                                  download_basket
+      checksum:                              17ace3bdb27647792a7ddab62df1513cf084568b88dc1bafd91ae9fef79b9e16
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_14.zip"
+      archive:                               S4CORE108_INST_EXPORT_14.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164332023
+      path:                                  download_basket
+      checksum:                              e530f67e5f5f6e77b37db46d1617e6cf709d44573e1190117b4cb17b420d645f
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_15.zip"
+      archive:                               S4CORE108_INST_EXPORT_15.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164352023
+      path:                                  download_basket
+      checksum:                              6620ad815d9d49e5a9965e3ec1e0dd21e2ced89f9f67839a093bef6b4773fcad
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_16.zip"
+      archive:                               S4CORE108_INST_EXPORT_16.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164362023
+      path:                                  download_basket
+      checksum:                              e79e8058d0b820098b3492a5f3e7df419a01302d74ff15213b563bf6f2cb67d2
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_17.zip"
+      archive:                               S4CORE108_INST_EXPORT_17.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164382023
+      path:                                  download_basket
+      checksum:                              7b7e0bed2dcb22ed38ed533a2103d055a868a81927d82387b787cf1b3bb0de89
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_18.zip"
+      archive:                               S4CORE108_INST_EXPORT_18.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164392023
+      path:                                  download_basket
+      checksum:                              759d6e3f1e0e5b9c1341523ee43dab842c9cc5d4f31836cfd887057d01c4fbfe
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_19.zip"
+      archive:                               S4CORE108_INST_EXPORT_19.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164412023
+      path:                                  download_basket
+      checksum:                              6a70d4f3899fff7ecf05903e51670646dc9c4ffd4bbf08b0577e31a0eea1007c
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_2.zip"
+      archive:                               S4CORE108_INST_EXPORT_2.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164422023
+      path:                                  download_basket
+      checksum:                              97e22796a956d3c2e6938d40b293e2b0e19f74a99fff9fb0f02e919032922b8e
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_20.zip"
+      archive:                               S4CORE108_INST_EXPORT_20.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164452023
+      path:                                  download_basket
+      checksum:                              e42c2270e9f697c831036f9a11e6b01405481d13365b09cc303649d6bd0628bd
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_21.zip"
+      archive:                               S4CORE108_INST_EXPORT_21.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164472023
+      path:                                  download_basket
+      checksum:                              d4bec3a7c63a926d87facacf10f2959363c65654660eada3d30165b0ff768aec
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_22.zip"
+      archive:                               S4CORE108_INST_EXPORT_22.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164502023
+      path:                                  download_basket
+      checksum:                              2c69d6d2080e7cc3aa79416ac758c6ad9c3ce666d840be98ffe470ec6061789d
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_23.zip"
+      archive:                               S4CORE108_INST_EXPORT_23.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164512023
+      path:                                  download_basket
+      checksum:                              821d491b650d62bb280d8a7062d63787da8e288844bd562181b5b8764e276e3d
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_24.zip"
+      archive:                               S4CORE108_INST_EXPORT_24.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164522023
+      path:                                  download_basket
+      checksum:                              f3cbff14a863821ac698abad50365902b6cd03fa0b587e4a85b6edc2c255fa61
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_25.zip"
+      archive:                               S4CORE108_INST_EXPORT_25.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164532023
+      path:                                  download_basket
+      checksum:                              8b45a1eff480937c0ae65d55d36001b1bf0067c433ab5adc5e13353232b34526
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_26.zip"
+      archive:                               S4CORE108_INST_EXPORT_26.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164542023
+      path:                                  download_basket
+      checksum:                              22418fb9d19c6edb7ec3f09966875eb7cd90eb392ccef010ae7c11772f3c3640
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_27.zip"
+      archive:                               S4CORE108_INST_EXPORT_27.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164562023
+      path:                                  download_basket
+      checksum:                              c310401f4e93a8f28662f458e9438c7a63543181c70a0afd80a7bc2467c4eb7d
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_28.zip"
+      archive:                               S4CORE108_INST_EXPORT_28.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164572023
+      path:                                  download_basket
+      checksum:                              daadff1f16e8b03c7ba66c9833294f23dacdb6b2fe0056604a779de165b04af6
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_29.zip"
+      archive:                               S4CORE108_INST_EXPORT_29.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164582023
+      path:                                  download_basket
+      checksum:                              c4be4ca05ca6ca9ce2aef191402646c3b2bcc1539795255507cbb32cbf0b9836
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_3.zip"
+      archive:                               S4CORE108_INST_EXPORT_3.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164592023
+      path:                                  download_basket
+      checksum:                              d0b618350e965d4d1863b78cc8dc4d38c79351619d96ce4edb3a27d4367f09e9
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_30.zip"
+      archive:                               S4CORE108_INST_EXPORT_30.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164612023
+      path:                                  download_basket
+      checksum:                              11bd446aeca3183b138ffd273da0e0c1ba2836a8f92f220d7ff0848d5cf0dc5a
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_4.zip"
+      archive:                               S4CORE108_INST_EXPORT_4.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164622023
+      path:                                  download_basket
+      checksum:                              e7b9cbabc5cdfb18b8445e7283ccb34d9e022a73c00dd1ebac5d705105d6e762
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_5.zip"
+      archive:                               S4CORE108_INST_EXPORT_5.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164632023
+      path:                                  download_basket
+      checksum:                              a0a6a6110a704543f9169b2b0ea05119e9307a4a7c0c02ad5822682edef3fe74
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_6.zip"
+      archive:                               S4CORE108_INST_EXPORT_6.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164652023
+      path:                                  download_basket
+      checksum:                              60dd95e469c1070fd3960c45ecc295e6694b5043fb88811a6db49cb06192c94c
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_7.zip"
+      archive:                               S4CORE108_INST_EXPORT_7.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164662023
+      path:                                  download_basket
+      checksum:                              83cc8fdf7d0cdcf53dd18729cb08284f1c70dc4f4285328a59fab6fab95f9d18
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_8.zip"
+      archive:                               S4CORE108_INST_EXPORT_8.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164672023
+      path:                                  download_basket
+      checksum:                              15a20f9845b30da00a1f5798144ca227f80c65bdbd9597dc17a73ccda6ce27aa
+
+    - name:                                  "File on DVD - S4CORE108_INST_EXPORT_9.zip"
+      archive:                               S4CORE108_INST_EXPORT_9.zip
+      url:                                   https://softwaredownloads.sap.com/file/0030000001164692023
+      path:                                  download_basket
+      checksum:                              2d8664057f1d7eac81757715ceff57348160b551fea4975f061cb3848e9c4b75
+
+    - name:                                  "File on DVD - S4HANAOP108_ERP_LANG_DE.SAR"
+      archive:                               S4HANAOP108_ERP_LANG_DE.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0030000001161662023
+      path:                                  download_basket
+      checksum:                              1566b80513c329510db89beaf5abd8f1caf73e072d92cb63ae33697cf6f81d98
+
+    - name:                                  "File on DVD - S4HANAOP108_ERP_LANG_EN.SAR"
+      archive:                               S4HANAOP108_ERP_LANG_EN.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0030000001161672023
+      path:                                  download_basket
+      checksum:                              d670dc013952e2456a9fbc68e1288f470bf3285643a48d92f5bd1c4093157687
+
+    # other components
+
+    - name:                                  "Attribute Change Package 28 for GBX01HR5 605"
+      archive:                               GBX01HR5605.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000033172015
+      download:                              false
+      checksum:                              9b5f3fca5b87ba80f4048f857a22b2a63033b58ffb977a19241b1316a4731701
+
+    - name:                                  "UIHR002 100: SP 0001"
+      archive:                               K-10001INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000020421312017
+      download:                              false
+      checksum:                              fcea0646281bea84985537527c8be840a328a08b24f36e458d98f3aa61040f08
+
+    - name:                                  "UIHR002 100: SP 0002"
+      archive:                               K-10002INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000493432018
+      download:                              false
+      checksum:                              3e9c7fab54796ad9ca241f9fd9a9edf82cfe9df152511b8b6796adafc8ed40c3
+
+    - name:                                  "UIHR002 100: SP 0003"
+      archive:                               K-10003INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001141912018
+      download:                              false
+      checksum:                              1c01075973bfc2bc3b41535ca27eb7c71220cdac529d79c40e83e21f8c5a1c97
+
+    - name:                                  "UIHR002 100: SP 0004"
+      archive:                               K-10004INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001934802018
+      download:                              false
+      checksum:                              9992f1728fa5ed4c320e3ff5d6e2162a53072d7dac22d9d257d56d22b672f279
+
+    - name:                                  "UIHR002 100: SP 0005"
+      archive:                               K-10005INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000045522019
+      download:                              false
+      checksum:                              8d7b880dfe89aebff047018f9ca86a0f7a831befdc856764f8ab124c4260068c
+
+    - name:                                  "UIHR002 100: SP 0006"
+      archive:                               K-10006INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000464552019
+      download:                              false
+      checksum:                              6f05090977e230c30feb2a25b24ee9780eae53b8ba7d79248736252623224002
+
+    - name:                                  "UIHR002 100: SP 0007"
+      archive:                               K-10007INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001273902019
+      download:                              false
+      checksum:                              4010e8821ce9badd733d92e8b372f0584e39bc0b5805e2af0ce1402ea8d5f09a
+
+    - name:                                  "UIHR002 100: SP 0008"
+      archive:                               K-10008INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001810332019
+      download:                              false
+      checksum:                              3d92662ec19af3af3acdeeac1b500c47ff613fe24b570ae0f81aa4616231093d
+
+    - name:                                  "UIHR002 100: SP 0009"
+      archive:                               K-10009INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000341482020
+      download:                              false
+      checksum:                              5ef6474c9ba556ba10cfa849f95a9791e612d1fe050747bfc06a2e93d0407422
+
+    - name:                                  "UIHR002 100: SP 0010"
+      archive:                               K-10010INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000979992020
+      download:                              false
+      checksum:                              0c568d19b8f4ea31dc00d651db24287386128395704f691657b2f6ad0d74af40
+
+    - name:                                  "UIHR002 100: SP 0011"
+      archive:                               K-10011INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001525832020
+      download:                              false
+      checksum:                              e45f87ba029f88ade45fd2c198a71986c8c935c76ae5a62e872b8b6f5a8398ea
+
+    - name:                                  "UIHR002 100: SP 0012"
+      archive:                               K-10012INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000002085752020
+      download:                              false
+      checksum:                              799288a50cf8e57fffb73462e17c8e87908f260833329ebd68ad8fd351364b77
+
+    - name:                                  "UIHR002 100: SP 0013"
+      archive:                               K-10013INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000335032021
+      download:                              false
+      checksum:                              69a457f49431ad66397b8b9078070ae296bac2f4943a2b098117583180bbaca6
+
+    - name:                                  "UIHR002 100: SP 0014"
+      archive:                               K-10014INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000819382021
+      download:                              false
+      checksum:                              d889cc1563769b27d591b8d2222fc5c67b38e5a577e11bc4c42a7bb0b91fae03
+
+    - name:                                  "UIHR002 100: SP 0015"
+      archive:                               K-10015INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001278192021
+      download:                              false
+      checksum:                              de8bfea033dab01e00cba79aac9e2a1953020544407f64ecd8a5c28d4a3c3810
+
+    - name:                                  "UIHR002 100: SP 0016"
+      archive:                               K-10016INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001713232021
+      download:                              false
+      checksum:                              dff7b0a1a61c0b31e57520fba89631c60b10235a9a0b2376bbf47c1805321704
+
+    - name:                                  "UIHR002 100: SP 0017"
+      archive:                               K-10017INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000335842022
+      download:                              false
+      checksum:                              8b253e80b06ac0f1177a3cdf90c3d881e092c7ae9d7ea12b6fa691f0c33130ec
+
+    - name:                                  "UIHR002 100: SP 0018"
+      archive:                               K-10018INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000733592022
+      download:                              false
+      checksum:                              310626b98a3685ed6ddbdafcc86e0322f99463dc3bbe9f954b87fa8b6c15d88a
+
+    - name:                                  "UIHR002 100: SP 0019"
+      archive:                               K-10019INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001142932022
+      download:                              false
+      checksum:                              0034e549e985ddeef22276a239e80642769cb991f13353cbc2ff35522cda0bc6
+
+    - name:                                  "UIHR002 100: SP 0020"
+      archive:                               K-10020INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001681592022
+      download:                              false
+      checksum:                              8016a50c637c13a8450577f9bc1f72631e4dbc0359002220c270773a167518a2
+
+    - name:                                  "UIHR002 100: SP 0021"
+      archive:                               K-10021INUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000242992023
+      download:                              false
+      checksum:                              b02bef1b245ea82a0429bee751cd28edc95a83a0f84289d980c41db208cfa3b3
+
+    - name:                                  "UIHR002 100: Add-On Installation"
+      archive:                               K-100AGINUIHR002.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000019183952017
+      download:                              false
+      checksum:                              704d117df4cac91c11d51767a57af7df08e484b5a6b9da79382e82465411b4a7
+
+    - name:                                  "UIMDG001 200: Support Package 0001"
+      archive:                               K-20001INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001029322016
+      download:                              false
+      checksum:                              3639089001a6f15dd04d74826160bbf50c01f5e6cd595a00efebb18bc155e70a
+
+    - name:                                  "UIMDG001 200: SP 0002"
+      archive:                               K-20002INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000014298612017
+      download:                              false
+      checksum:                              7c4872138665abcc330fa0d19e684614acf24e39432c28a1d5cb0e8aaf9567b2
+
+    - name:                                  "UIMDG001 200: SP 0003"
+      archive:                               K-20003INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000019125502017
+      download:                              false
+      checksum:                              861af02e6f495c92d0dc49f2677fd3642f15b69e87e0c124257a4f1edb9064eb
+
+    - name:                                  "UIMDG001 200: SP 0004"
+      archive:                               K-20004INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000019849022017
+      download:                              false
+      checksum:                              d9c795e1d59924dbe4d0990f7df1ab0810c87b06d98f3fe712b1ac20fd8b685e
+
+    - name:                                  "UIMDG001 200: SP 0005"
+      archive:                               K-20005INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000020421762017
+      download:                              false
+      checksum:                              529614708b9b17b002b1c3f5eb9082cad12d738a40d19de52ea1120746494ffa
+
+    - name:                                  "UIMDG001 200: SP 0006"
+      archive:                               K-20006INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000493392018
+      download:                              false
+      checksum:                              eb5a15d27b619ae30e16992eca95379af3634ee0b0a9b1c62f761c891a05b5cf
+
+    - name:                                  "UIMDG001 200: SP 0007"
+      archive:                               K-20007INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001935022018
+      download:                              false
+      checksum:                              2690224cca026a4024c5ebdbbfcdf64151cc5122c3b2f7a3d824b4f9f3405197
+
+    - name:                                  "UIMDG001 200: SP 0008"
+      archive:                               K-20008INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000464372019
+      download:                              false
+      checksum:                              e3889def8a21765d43bbee56ed4c24b7ecdf2b85a7b2652481d20942101ca127
+
+    - name:                                  "UIMDG001 200: SP 0009"
+      archive:                               K-20009INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001525852020
+      download:                              false
+      checksum:                              ffa03f6352323ddc48c91fefbcbccec8f17be6e3a031a72b6493f4832dc391c1
+
+    - name:                                  "UIMDG001 200: SP 0010"
+      archive:                               K-20010INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000002085772020
+      download:                              false
+      checksum:                              093bb0d51add5f3886f3f74174d5137e0a26740f7159b3eef824cc1c8d788720
+
+    - name:                                  "UIMDG001 200: SP 0011"
+      archive:                               K-20011INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001278222021
+      download:                              false
+      checksum:                              e73c99075ec2348a649bda5eba57f97a0bbb7c7dd243e858c704dc7baf4300fd
+
+    - name:                                  "UIMDG001 200: SP 0012"
+      archive:                               K-20012INUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000335852022
+      download:                              false
+      checksum:                              84c6f3ffce55e0ca00b6a19ac5babf5327e519e4b059861ea94140baae204305
+
+    - name:                                  "UIMDG001 200: SP 0013"
+      archive:                               K-20013INUIMDG001.SAR
+      download:                              false
+      url:                                   https://softwaredownloads.sap.com/file/0010000000256792023
+      checksum:                              e5356fc4034c9365e0a69b0c4789c467ee3ea39a270799531a934e68fa99ff41
+
+    - name:                                  "UIMDG001 200: Add-On Installation"
+      archive:                               K-200AGINUIMDG001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000696272016
+      download:                              false
+      checksum:                              9467d4a3a3e8aec8f8a7139863ba6f903ce5ae6aa16f4d0a726e709501a581ab
+
+    - name:                                  "UITRV001 300: SP 0001"
+      archive:                               K-30001INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000045572019
+      download:                              false
+      checksum:                              d54e623fc3ad3a4b617ea5f1c94eddefd8f51ac43e3b0626d095d4c05e4cd1e9
+
+    - name:                                  "UITRV001 300: SP 0002"
+      archive:                               K-30002INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001273832019
+      download:                              false
+      checksum:                              8a66ff2c8ae7077bb35014dedc629cd775fdb2731e6a34f513a2f251030101ff
+
+    - name:                                  "UITRV001 300: SP 0003"
+      archive:                               K-30003INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001810452019
+      download:                              false
+      checksum:                              e7d9b4924bb946e06f386aedc98f8a6ddf6bf78c1bfb534cc1bc88ae3862b583
+
+    - name:                                  "UITRV001 300: SP 0004"
+      archive:                               K-30004INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000341512020
+      download:                              false
+      checksum:                              39aa1d34fe9b12db2c9141a2bc1c16388a8c696ad12a2df4a935bb49c585802d
+
+    - name:                                  "UITRV001 300: SP 0005"
+      archive:                               K-30005INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001616922020
+      download:                              false
+      checksum:                              80a791a3939e8c53cabcb69f9c07e21aac6d9f23938a33fd70a66741089dec4b
+
+    - name:                                  "UITRV001 300: SP 0006"
+      archive:                               K-30006INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000335052021
+      download:                              false
+      checksum:                              e90f40adbfc56cd39e293589041e1dc83adbbc39aec4f1944781ef0f13d9bb9e
+
+    - name:                                  "UITRV001 300: SP 0007"
+      archive:                               K-30007INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001278572021
+      download:                              false
+      checksum:                              442d12c4760a678d7e7969b39d2907e00d97f93874fa08e1c5d423786ff53f33
+
+    - name:                                  "UITRV001 300: SP 0008"
+      archive:                               K-30008INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000337402022
+      download:                              false
+      checksum:                              3cb902d7570a77be33f7feb5a71a0a880442f5720ba0505a305814af245b1063
+
+    - name:                                  "UITRV001 300: SP 0009"
+      archive:                               K-30009INUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001144932022
+      download:                              false
+      checksum:                              a8d588099c7d35a73c59d2088c301f4083ea208e012829b23ee74a15fbb157bb
+
+    - name:                                  "UITRV001 300: Add-On Installation"
+      archive:                               K-300AGINUITRV001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001909232018
+      download:                              false
+      checksum:                              ab970fce38141f3fc2752fb2169447681bb739471ebbb37385058eb50f72f02f
+
+    - name:                                  "ST-PI 740: SP 0024"
+      archive:                               K-74024INSTPI.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001020382023
+      download:                              false
+      checksum:                              f3cd6652bb1e820a1dba1c0515005d27380d8bf3fef244f17edf6748ce4a5239
+
+    - name:                                  "UIBAS001 758: Add-On Installation"
+      archive:                               K-758AGINUIBAS001.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000407272023
+      download:                              false
+      checksum:                              c174a30f50a76bd2d2735412287675e05ffc3412528b75489cd9d1336140dc6e
+
+    - name:                                  "UIS4HOP1 900: Add-On Installation"
+      archive:                               K-900AGINUIS4HOP1.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000704582023
+      download:                              false
+      checksum:                              2ff2ef8e5528751c1738b980636af4eb59cb2241a1e4a9712de9f982149bae1c
+
+    - name:                                  "UIAPFI70 902: Add-On Installation"
+      archive:                               SAPK-902AGINUIAPFI70
+      url:                                   https://softwaredownloads.sap.com/file/0010000000703232023
+      download:                              false
+      checksum:                              18b2edd5348a6b523b3b9ee7f900b79d1edf97acb638306c6b388fac71f9e46a
+
+    - name:                                  "SPAM/SAINT Update - Version 758/0086"
+      archive:                               KD75886.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000916642023
+      download:                              false
+      checksum:                              c762aeb158716c051303b46a3cf77c35c2e0fff580aeb04e56a2d1bc83861514
+
+    - name:                                  "Servicetools for SAP Basis 731 and higher"
+      archive:                               KITABC5.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001370422022
+      download:                              false
+      checksum:                              6c6fc1d02395bec4ddacd592d0db7e6173168dd4066f89dd061b097b51f168a0
+
+    - name:                                  "Servicetools for SAP Basis 731 and higher"
+      archive:                               KITABC6.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000001370422022
+      download:                              false
+      checksum:                              6c6fc1d02395bec4ddacd592d0db7e6173168dd4066f89dd061b097b51f168a0
+
+    - name:                                  "Attribute Change Package 56 for ST-PI 740"
+      archive:                               ST-PI740.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000297212015
+      download:                              false
+      checksum:                              603e83e417638508f7bfda9eed3e2f13bf7853e26439e5ff494ce9d51a930da5
+
+    - name:                                  "Attribute Change Package 36 for UIHR002 100"
+      archive:                               UIHR002100.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000020208092017
+      download:                              false
+      checksum:                              689436077b2a9033cba4e2805127d351d580e61916952f060b3758991b6d5faf
+
+    - name:                                  "Attribute Change Package 18 for UIMDG001 200"
+      archive:                               UIMDG001200.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000014247222017
+      download:                              false
+      checksum:                              efe6263197cdbb31f80bf4770d3431cc03c4d6aed954e33d68ce930eac5ffa2a
+
+    - name:                                  "Attribute Change Package 19 for UITRV001 300"
+      archive:                               UITRV001300.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0010000000561182019
+      download:                              false
+      checksum:                              049a690586683062f6f4ef887a70e11479eefafdb467619b6dc5f920dd32ac86
+
+...


### PR DESCRIPTION
This pull request introduces a new YAML configuration file for SAP HANA 2.0 SPS08 Revision 086, detailing the required media and their metadata for installation. The file specifies the necessary archives, checksums, extraction instructions, and download URLs for each component needed for a complete HANA 2.0 setup.

**New SAP HANA 2.0 SPS08 Revision 086 media definition:**

* Added `HANA_2_00_086_v0001ms.yaml` specifying all required installation components, including SAPCAR, HANA Client, HANA Server, AFL, LCAPPS, VCH AFL, and SAP Host Agent, with details such as archive names, checksums, extraction paths, and download URLs.