### PR TITLE
feat: Update IMDB_SERVER20 package version and checksum in YAML file

### DIFF
--- a/SAP/HANA_2_00_SPS08_latest/HANA_2_00_SPS08_latest.yaml
+++ b/SAP/HANA_2_00_SPS08_latest/HANA_2_00_SPS08_latest.yaml
@@ -32,14 +32,14 @@ materials:
       path:                                  download_basket
       url:                                   https://softwaredownloads.sap.com/file/0025000000128362026
 
-    - name:                                  "Revision 2.00.089.1 (SPS08) for HANA DB 2.0"
-      archive:                               IMDB_SERVER20_089_1-80002031.SAR
-      checksum:                              e6655f9fd3a1c1e8a234dc10096cf60ef0f6a3103119da7ac1f046bc59db078a
+    - name:                                  "Revision 2.00.089.2 (SPS08) for HANA DB 2.0"
+      archive:                               IMDB_SERVER20_089_2-80002031.SAR
+      checksum:                              923fe77857539400801e920acd9369ee3c1540773fee1ad750ee06300781a2aa
       extract:                               true
       extractDir:                            CD_HDBSERVER
       creates:                               SIGNATURE.SMF
       path:                                  download_basket
-      url:                                   https://softwaredownloads.sap.com/file/0025000000041962026
+      url:                                   https://softwaredownloads.sap.com/file/0025000000154312026
 
     - name:                                  "SAP HANA AFL Rev 89.100 only for HANA 2.0 Rev 89.01"
       archive:                               IMDB_AFL20_089P_100-80001894.SAR
@@ -65,10 +65,10 @@ materials:
       creates:                               COMPONENTS/VCH_AFL_2021/packages
       url:                                   https://softwaredownloads.sap.com/file/0025000000042172026
 
-    - name:                                 "SAP HOST AGENT 7.22 SP69 ; OS: Linux on x86_64 64bit"
-      archive:                              SAPHOSTAGENT69_69-80004822.SAR
-      url:                                  https://softwaredownloads.sap.com/file/0025000000056272025
-      download:                             True
-      path:                                 download_basket
+    - name:                                  "SAP HOST AGENT 7.22 SP69 ; OS: Linux on x86_64 64bit"
+      archive:                               SAPHOSTAGENT69_69-80004822.SAR
+      url:                                   https://softwaredownloads.sap.com/file/0025000000056272025
+      download:                              True
+      path:                                  download_basket
 
 ...


### PR DESCRIPTION
This pull request updates the SAP HANA 2.0 SPS08 material definition to use the latest patch revision for the main HANA DB server package.

**SAP HANA DB Server Update:**

* Updated the main HANA DB 2.0 SPS08 server package from revision 2.00.089.1 to 2.00.089.2, including the new archive name, checksum, and download URL.