### PR TITLE
feat: Update version and details for Patch 5 in SUM20SP25 YAML file

### DIFF
--- a/SAP/SUM20SP25_latest/SUM20SP25_latest.yaml
+++ b/SAP/SUM20SP25_latest/SUM20SP25_latest.yaml
@@ -3,15 +3,15 @@
 
 name:                                  'SUM20SP25'
 target:                                'SUM20SP25'
-version:                               004
+version:                               005
 
 materials:
 
   media:
   # SUM
-  - name:                              "Patch 4 for SOFTWARE UPDATE MANAGER 2.0 SP25 (Linux on x86_64)"
-    archive:                           SUM20SP25_4-80002456.SAR
-    checksum:                          e06c78cec8aea613c156fd774b377cf7b0d85aea4111308b8cafa82f35c73ea6
+  - name:                              "Patch 5 for SOFTWARE UPDATE MANAGER 2.0 SP25 (Linux on x86_64)"
+    archive:                           SUM20SP25_5-80002456.SAR
+    checksum:                          ecb7db5df65a765c4bb89cf1da7dbf7611d76e1b43f1aa5d9f5102e9660b8c14
     download:                          false
-    url:                               https://softwaredownloads.sap.com/file/0025000000116042026
+    url:                               https://softwaredownloads.sap.com/file/0025000000154582026
 


### PR DESCRIPTION
This pull request updates the SUM patch version in the `SAP/SUM20SP25_latest/SUM20SP25_latest.yaml` configuration file to use the latest available patch. The update ensures that the deployment references Patch 5 instead of Patch 4, along with the associated archive, checksum, and download URL.

**Patch version update:**

* Updated the `version` field from `004` to `005` to reflect the new patch level.
* Replaced the media entry for SUM Patch 4 with Patch 5, updating the `name`, `archive`, `checksum`, and `url` fields accordingly.