### PR TITLE
Use SUM 2.0 SP26 for S/4HANA 2025

### DIFF
--- a/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
+++ b/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
@@ -32,7 +32,7 @@ materials:
   dependencies:
     - name:                             "HANA_2_00_SPS08_latest"
     - name:                             "SWPM20SP24_latest"
-    - name:                             "SUM20SP25_latest"
+    - name:                             "SUM20SP26_latest"
   media:
     - name:                             "Kernel Part I (916) ; OS: Linux on x86_64 64bit ; DB: Database independent"
       archive:                          SAPEXE_50-70008102.SAR


### PR DESCRIPTION
Updates the S4_2025_SPS08ms dependency from retired SUM 2.0 SP25 patch 8 to the current SUM 2.0 SP26 patch 3 BOM. The SP25 download returns HTTP 404; SUM20SP26_latest contains the active archive metadata and checksum.