### PR TITLE
docs: add samples and BOM journey

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,119 @@
+# Contributing to SAP automation samples
+
+Thank you for contributing Terraform examples, SAP software definitions, BOM
+components, Ansible examples, or documentation.
+
+Most contributions require you to agree to a Contributor License Agreement
+(CLA) that confirms you have the right to grant us permission to use the
+contribution. For details, see the
+[Microsoft CLA](https://cla.opensource.microsoft.com). The CLA bot checks pull
+requests and provides instructions when action is required.
+
+This project follows the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+
+## Confirm ownership
+
+Submit a change here when it updates:
+
+- a Terraform example under `Terraform`;
+- a predefined SAP definition under `SAP`;
+- an application, database, or kernel component under `BOM`;
+- an Ansible example under `Ansible`; or
+- documentation for these assets.
+
+Submit Terraform module, Ansible role, downloader, validator, installation, or
+local script changes to
+[`Azure/sap-automation`](https://github.com/Azure/sap-automation). Submit
+workflow or pipeline wrapper changes to the repository that owns that execution
+model.
+
+## General requirements
+
+1. **Create** a focused branch from the current default branch.
+2. **Identify** the source asset, consumer, and execution models affected by the
+   change.
+3. **Use** official vendor source data for Azure, Terraform, Ansible, and SAP
+   values. Link the source in the pull request.
+4. **Exclude** credentials, tokens, customer data, downloaded SAP software,
+   Terraform state, and generated execution artifacts.
+5. **Preserve** existing paths and naming conventions unless the change
+   includes a compatibility reason and updates all in-repository references.
+6. **Validate** only the affected assets with the current SDAF implementation
+   and record the commands, versions, and results in the pull request.
+7. **Run** `git diff --check` and review the final documentation and data-only
+   diff.
+
+## Contribute a Terraform sample
+
+1. **Place** the sample in the matching `Terraform/WORKSPACES` stage directory:
+   `DEPLOYER`, `LIBRARY`, `LANDSCAPE`, or `SYSTEM`.
+2. **Match** the directory name and `.tfvars` file stem. Follow the established
+   stage naming pattern described in
+   [Use Terraform workspace samples](docs/01-00-terraform-samples.md).
+3. **Replace** real subscriptions, tenants, credentials, customer domains,
+   addresses, and resource identifiers with safe example values.
+4. **Document** the topology and any nondefault dependency in the applicable
+   existing `readme.md`.
+5. **Compare** every variable with the matching root module at the SDAF version
+   used for validation.
+6. **Run** the plan or test mode through an execution path that consumes the
+   sample. Review the plan for unexpected changes and destructive actions.
+7. **Record** the SDAF commit, sample path, command or workflow, and plan result
+   in the pull request.
+
+A formatting or parsing check alone is not sufficient because sample values
+control Azure architecture, cost, and state.
+
+## Contribute an SAP or BOM definition
+
+1. **Choose** `SAP` for a predefined complete product definition or `BOM` for a
+   separate application, database, or kernel component.
+2. **Match** the directory name and YAML file stem exactly.
+3. **Follow** the naming and version pattern already used by the same product
+   family. Do not infer one family convention from another.
+4. **Update** product metadata, dependencies, media URLs, archive names,
+   checksums, platforms, and compatibility fields from verifiable SAP source
+   data.
+5. **Preserve** the previous predefined SAP definition when the existing
+   versioning procedure requires archival. Follow
+   [`SAP/TSG/bomlinkupdate.md`](SAP/TSG/bomlinkupdate.md) for link updates and
+   the special `latest` handling documented there.
+6. **Run** the current SDAF BOM validator with the repository root as
+   `BOM_directory` and the exact changed definition or component selection.
+7. **Run** the applicable software-acquisition path when credentials and
+   entitlements are available. Confirm dependency resolution, compatibility,
+   download results, and checksums.
+8. **Record** source links, the catalog commit, selected names, validator
+   output, and any media that could not be entitlement-tested.
+
+Do not weaken or remove a checksum to make a download pass. Do not claim that
+obsolete SAP media is supported or replaceable without verifiable SAP source
+data.
+
+## Contribute an Ansible example
+
+1. **Keep** the change under `Ansible` and limit it to sample behavior.
+2. **Use** fully qualified Ansible collection names.
+3. **Remove** environment-specific hosts, credentials, and customer data.
+4. **Run** syntax and lint validation with the Ansible versions used by the
+   current SDAF repository.
+5. **Move** executable framework behavior to `Azure/sap-automation` when the
+   change belongs in a shared role or playbook.
+
+## Contribute documentation
+
+1. **Use** sentence-case headings, short sentences, active voice, and explicit
+   numbered actions.
+2. **Use** relative links for files in this repository.
+3. **Verify** every path, variable, and command against the current source.
+4. **Preserve** useful existing paths and heading anchors.
+5. **Check** every relative link and heading anchor, then run
+   `git diff --check`.
+
+## Report validation limits
+
+State any validation that you could not perform. Explain whether the limit was
+caused by SAP entitlement, unavailable media, Azure access, cost, or execution
+environment. A pull request must not describe untested media or infrastructure
+as validated.

--- a/README.md
+++ b/README.md
@@ -1,55 +1,85 @@
-# Project
+# SAP Deployment Automation Framework samples
 
-This repo contains both the sample Terraform configuration files for SDAF and the Bill of Material files for the SAP installations
+This repository contains shared configuration examples and SAP software
+definitions for the SAP Deployment Automation Framework (SDAF). GitHub Actions,
+Azure DevOps, and local execution can use these assets. Samples and bill of
+materials (BOM) files are inputs to those three execution models. They are not a
+fourth execution model.
 
-## Contributing
+For framework architecture, execution-model selection, and lifecycle guidance,
+start at the central [`Azure/sap-automation`](https://github.com/Azure/sap-automation)
+hub.
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.
+## Before you use a sample
 
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+1. **Select** GitHub Actions, Azure DevOps, or local execution in the central
+   hub.
+2. **Pin** compatible, reviewed commits or releases for the framework,
+   execution repository, and this repository.
+3. **Copy and customize** only the required sample assets in the repository
+   that owns your deployment configuration.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+## Choose a task
+
+| Task | Start here |
+| --- | --- |
+| Prepare infrastructure configuration | [Use Terraform workspace samples](docs/01-00-terraform-samples.md) |
+| Select SAP software definitions and BOM files | [Use SAP and BOM samples](docs/02-00-bom-samples.md) |
+| Review an Ansible example | [`Ansible/playbook.yml`](Ansible/playbook.yml) |
+| Propose a sample or BOM change | [Contribute to the repository](CONTRIBUTING.md) |
+
+## Understand the repository content
+
+| Path | Content | How to use it |
+| --- | --- | --- |
+| [`Terraform/WORKSPACES`](Terraform/WORKSPACES/) | Example `.tfvars` files for deployers, SAP libraries, workload zones, and SAP systems | Copy a selected example to your configuration repository, then replace environment-specific values before planning a deployment. |
+| [`Terraform/RESOURCE_NAMES`](Terraform/RESOURCE_NAMES/) | Example resource-name definitions | Review and adapt the definitions only when your deployment path uses a custom resource-naming file. |
+| [`SAP`](SAP/) | Predefined SAP product BOM definitions, dependencies, templates, and media records | Select a complete definition by its directory and YAML file stem. |
+| [`BOM`](BOM/) | Separate application, database, and SAP kernel BOM component definitions | Select compatible components when your software-acquisition path assembles a combined BOM. |
+| [`Ansible`](Ansible/) | Ansible sample content | Use the content as an example. The executable SDAF Ansible roles and playbooks are owned by the central repository. |
+
+`Terraform/WORKSPACES/BOMS/sap-parameters.yaml` is an example software-
+acquisition parameter file. It is not the BOM catalog. The active catalog
+definitions are under `SAP` and `BOM`.
 
 ## How it works
 
-During software acquisition both the sample repositories and the sap-automation repositories need to be present on the deployer-agent. Each of the repositories will be mapped using the following:
+Keep three types of content separate:
 
-- sap-automation will be mapped to ```/sap-automation```
-- customer configuration repository will be mapped to ```/config```
-- sample repository will be mapped to ```/samples```
+1. Store reviewed infrastructure configuration in your customer configuration
+   repository under `WORKSPACES`.
+2. Keep the SDAF implementation in the
+   [`Azure/sap-automation`](https://github.com/Azure/sap-automation) checkout.
+3. Make this repository available to the selected execution model when it
+   resolves SAP software definitions.
 
-During execution the repositories will interact with each other by using the following:
+The Ansible variable `BOM_directory` identifies the root of this repository.
+The BOM registration role appends `SAP/<name>/<name>.yaml` and then
+`BOM/<name>/<name>.yaml` when it resolves a definition. Do not set
+`BOM_directory` to the `SAP` or `BOM` subdirectory.
 
-```mermaid
-flowchart LR
-    subgraph deployer-agent
-        pipeline--uses-->templated-pipelines
-        templated-pipelines--uses-->bom-name
-        subgraph 'WORKSPACES'
-            bom-name
-            pipeline
-        end
-        subgraph 'sap-automation'
-        templated-pipelines--executes-->software-download
-        end
-        subgraph 'sap-automation-samples'
-        bom-name--defines-->SAP-application
-        end
-    end
-```
+Pin a reviewed repository commit or release for reproducible deployments.
+Review every sample before use. Names, subscriptions, regions, network ranges,
+DNS settings, virtual-machine sizes, credentials, and SAP media availability
+are environment-specific.
 
-The Ansible playbooks leverage a variable ```BOM_directory``` that should contain the path to the cloned 'sap-samples' repository. 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for source, naming, validation, and pull
+request requirements.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information, see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com).
 
 ## Trademarks
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft
-trademarks or logos is subject to and must follow
+This project may contain trademarks or logos for projects, products, or
+services. Authorized use of Microsoft trademarks or logos is subject to and
+must follow
 [Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
-Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
-Any use of third-party trademarks or logos are subject to those third-party's policies.
+Use of Microsoft trademarks or logos in modified versions of this project must
+not cause confusion or imply Microsoft sponsorship. Use of third-party
+trademarks or logos is subject to the third party's policies.

--- a/docs/01-00-terraform-samples.md
+++ b/docs/01-00-terraform-samples.md
@@ -36,7 +36,8 @@ The repository also contains:
   software-acquisition parameter file.
 - `Terraform/RESOURCE_NAMES/X00_resource_names.json`, an example custom
   resource-name definition.
-- `export.sh`, `export_cp.sh`, and `export_wl.sh`, local shell examples with
+- `Terraform/WORKSPACES/export.sh`, `Terraform/WORKSPACES/export_cp.sh`, and
+  `Terraform/WORKSPACES/export_wl.sh`, local shell examples with
   environment-specific paths and empty identity values. Do not treat them as
   production defaults.
 

--- a/docs/01-00-terraform-samples.md
+++ b/docs/01-00-terraform-samples.md
@@ -1,0 +1,134 @@
+# Use Terraform workspace samples
+
+Use the Terraform workspace samples to prepare reviewed infrastructure
+configuration for an SDAF deployment.
+
+## Outcome
+
+You have environment-specific `.tfvars` files in your customer configuration
+repository. The files retain the directory structure expected by your selected
+GitHub Actions, Azure DevOps, or local execution path.
+
+## Before you begin
+
+- Select an SDAF execution model in the
+  [`Azure/sap-automation`](https://github.com/Azure/sap-automation) hub.
+- Clone or download this repository at a reviewed commit.
+- Obtain the approved architecture, subscription, identity, networking, DNS,
+  region, availability, sizing, and naming decisions for the deployment.
+- Identify the branch and directory in your customer configuration repository
+  that owns `WORKSPACES`.
+
+## Inputs
+
+| Deployment stage | Sample path | Directory and file pattern |
+| --- | --- | --- |
+| Deployer | `Terraform/WORKSPACES/DEPLOYER` | `<environment>-<region>-<deployer>-INFRASTRUCTURE/<same-name>.tfvars` |
+| SAP library | `Terraform/WORKSPACES/LIBRARY` | `<environment>-<region>-SAP_LIBRARY/<same-name>.tfvars` |
+| Workload zone | `Terraform/WORKSPACES/LANDSCAPE` | `<environment>-<region>-<network>-INFRASTRUCTURE/<same-name>.tfvars` |
+| SAP system | `Terraform/WORKSPACES/SYSTEM` | `<environment>-<region>-<network>-<SAP-system-id>/<same-name>.tfvars` |
+
+The repository also contains:
+
+- `Terraform/WORKSPACES/CONFIGURATIONS/anf_sizes.json`, an example Azure NetApp
+  Files sizing configuration.
+- `Terraform/WORKSPACES/BOMS/sap-parameters.yaml`, an example
+  software-acquisition parameter file.
+- `Terraform/RESOURCE_NAMES/X00_resource_names.json`, an example custom
+  resource-name definition.
+- `export.sh`, `export_cp.sh`, and `export_wl.sh`, local shell examples with
+  environment-specific paths and empty identity values. Do not treat them as
+  production defaults.
+
+## Ownership
+
+This repository owns the sample values and sample directory structure. Your
+customer configuration repository owns every copied and customized file. The
+central `Azure/sap-automation` repository owns Terraform behavior. The GitHub
+Actions or Azure DevOps bootstrap repository owns its execution wrapper.
+
+## What the automation does
+
+This repository does not run Terraform. Your selected execution model passes
+the copied `.tfvars` file to the matching SDAF root module. The resulting
+Terraform plan, state, and Azure resources belong to that deployment, not to
+this samples repository.
+
+## Review before execution
+
+Do not deploy an example without review. Sample files can contain illustrative
+resource names, address spaces, regions, DNS values, virtual-machine sizes,
+storage settings, and references to other sample environments.
+
+- Confirm that the target subscription and tenant are correct.
+- Check every network range for overlap.
+- Review resource SKUs, redundancy, and cost.
+- Remove or replace sample identifiers and cross-environment references.
+- Keep credentials and secret values outside committed `.tfvars` files.
+- Preserve existing Terraform state. Do not run concurrent operations against
+  the same state.
+
+## Prepare the configuration
+
+1. **Select** the stage directory that matches the resource you need to
+   configure. Read its existing `readme.md` when one is present.
+2. **Choose** the closest sample based on topology and platform, not only on its
+   environment label. Record the source commit and sample path.
+3. **Copy** the complete sample directory into
+   `WORKSPACES/<stage>` in your customer configuration repository.
+4. **Rename** the copied directory and `.tfvars` file together. Keep the file
+   stem identical to the directory name and follow the pattern in the inputs
+   table.
+5. **Replace** all sample-specific values with approved values for your
+   environment. Review optional blocks instead of assuming that commented or
+   populated examples apply.
+6. **Review** any referenced JSON, remote network, DNS, key vault, storage, or
+   control-plane values. Confirm that each referenced artifact exists in your
+   configuration.
+7. **Commit** the customized files to a review branch in the customer
+   configuration repository. Do not modify the source sample in place for a
+   deployment.
+8. **Run** the plan or test mode documented by your selected execution model.
+   Use the reviewed configuration commit and the intended Terraform state.
+
+After these steps, the plan must use the copied file from your customer
+configuration repository, not the original file in this repository.
+
+## Validate
+
+1. Confirm that the copied directory and `.tfvars` file have the same stem.
+2. Search the copied files for sample environment names, placeholder values,
+   unexpected subscriptions, and credentials.
+3. Run `git diff --check` in the customer configuration repository.
+4. Review the complete Terraform plan. Verify the resource names, locations,
+   address spaces, DNS configuration, SKUs, quantities, and destructive
+   actions.
+5. Record the sample source commit, configuration commit, SDAF version, and
+   approved plan with the deployment change.
+
+Do not use a successful syntax check as approval to deploy. The reviewed
+Terraform plan is the observable validation for environment-specific values.
+
+## If it fails
+
+- If a path is not found, verify the `WORKSPACES/<stage>/<name>/<name>.tfvars`
+  structure and case.
+- If Terraform rejects a variable, compare the copied file with the variables
+  in the matching root module at the SDAF version you are running.
+- If the sample itself is incorrect, open an issue in
+  [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples/issues)
+  and include the sample path, source commit, expected result, and plan error.
+- If the Terraform module fails independently of the sample values, report the
+  problem to
+  [`Azure/sap-automation`](https://github.com/Azure/sap-automation/issues).
+- If only a workflow or pipeline wrapper fails, use the repository that owns
+  that execution model.
+
+Do not apply a plan until the owning configuration and implementation issues
+are resolved.
+
+## Next step
+
+Return to the selected execution-model journey in the
+[`Azure/sap-automation`](https://github.com/Azure/sap-automation) hub. Complete
+its plan review and deployment procedure for the configured stage.

--- a/docs/02-00-bom-samples.md
+++ b/docs/02-00-bom-samples.md
@@ -1,0 +1,151 @@
+# Use SAP and BOM samples
+
+Use the SAP and BOM catalogs to select the software definitions consumed by
+SDAF software acquisition and installation.
+
+## Outcome
+
+You have selected a source-backed SAP software definition, configured the
+catalog root and BOM name correctly, and validated the selection through your
+execution model before installation.
+
+## Before you begin
+
+- Select GitHub Actions, Azure DevOps, or local execution in the
+  [`Azure/sap-automation`](https://github.com/Azure/sap-automation) hub.
+- Clone this repository at a reviewed commit on the runner, agent, or local
+  execution host.
+- Obtain SAP software-download credentials and confirm that the account is
+  entitled to the selected media.
+- Confirm the SAP product, release, database platform and version, operating
+  system, kernel, and installation topology.
+- Confirm that the target software library has enough capacity for the media.
+
+## Inputs
+
+| Input | Meaning |
+| --- | --- |
+| `BOM_directory` | The root directory of this repository. The Ansible BOM registration role searches `<BOM_directory>/SAP/<name>/<name>.yaml` and then `<BOM_directory>/BOM/<name>/<name>.yaml`. |
+| `bom_base_name` | The exact directory and YAML file stem for a predefined definition, or the hyphen-separated component selection passed to the dynamic BOM validator. |
+| `application_bom_name` | An application component directory under `BOM`, such as an `APP_...` definition. |
+| `database_bom_name` | A database component directory under `BOM`, such as a `DB_...` definition. |
+| `sap_kernel_bom_name` | A kernel component directory under `BOM`, such as a `SAP_KERNEL_...` definition. |
+| `save_bom_as` | The output name used by the dynamic BOM path when it assembles compatible components. |
+| `bom_name` | An SAP-system `.tfvars` value that records the BOM selected for that system. It is not a filesystem path. |
+
+`Terraform/WORKSPACES/BOMS/sap-parameters.yaml` is an example parameter file.
+It does not replace the `SAP` or `BOM` catalog.
+
+## Understand `SAP` and `BOM`
+
+- [`SAP`](../SAP/) contains predefined product BOMs. A definition can include
+  product identifiers, dependencies, installation templates, media URLs, and
+  checksums. Select these definitions as one complete BOM name.
+- [`BOM`](../BOM/) contains separate application, database, and SAP kernel
+  components. The BOM validator can combine selected components and checks
+  compatibility fields exposed by the application definition.
+- `SAP/archives` preserves earlier predefined definitions. Do not select an
+  archived definition unless your reviewed release procedure explicitly
+  requires it.
+
+Both active directories use `<name>/<name>.yaml`. Names and capitalization are
+significant.
+
+## Ownership
+
+This repository owns the checked-in SAP and BOM definitions. The central
+`Azure/sap-automation` repository owns the Ansible BOM validator, downloader,
+and installation behavior. Your selected execution repository owns its
+workflow or pipeline inputs. SAP owns the software-download service and media
+entitlements.
+
+## What the automation does
+
+The execution model makes this repository available to SDAF and passes
+`BOM_directory` and the selected name or component names. The Ansible
+registration role resolves definitions under `SAP` and `BOM`. The BOM
+validator loads dependencies, checks declared application, database, and
+kernel compatibility for dynamic selections, and assembles the effective media
+list. The software-acquisition path then downloads the entitled media to the
+configured target.
+
+## Review before execution
+
+- Treat URLs and checksums as version-specific source data.
+- Verify that application compatibility fields include the selected database
+  platform, database version, and kernel when those fields are present.
+- Review every dependency and media record required by the selected
+  definition.
+- Confirm that the download destination is the intended SAP software library.
+- Do not add SAP credentials, access tokens, or downloaded software to this
+  repository.
+- Pin the sample commit. A name containing `latest` can change in a later
+  commit.
+
+## Select and run a BOM
+
+1. **Choose** a predefined definition from `SAP` when your execution path
+   accepts one complete BOM name, or choose compatible application, database,
+   and kernel components from `BOM` when it supports dynamic assembly.
+2. **Verify** that each selected directory contains a YAML file with the same
+   stem. Record the repository commit and every selected name.
+3. **Inspect** the selected YAML files. Confirm the product, release, platform,
+   version, dependencies, media archives, URLs, and checksums against the
+   approved SAP design.
+4. **Set** `BOM_directory` to the repository root that contains the sibling
+   `SAP` and `BOM` directories. Do not set it to either subdirectory.
+5. **Set** the BOM input required by your execution model. Use the exact
+   predefined stem or the exact application, database, kernel, and output names
+   supported by that path.
+6. **Run** the software-acquisition test or download procedure in the selected
+   execution-model documentation. Use the reviewed repository commit and
+   destination.
+7. **Review** the validator and downloader output before starting SAP
+   installation.
+
+After these steps, the logs must identify the intended source definitions and
+must not report a missing BOM or incompatible component selection.
+
+## Validate
+
+1. Confirm that `BOM_directory/SAP` and `BOM_directory/BOM` both exist.
+2. Confirm that every selected `<name>/<name>.yaml` path exists with exact
+   capitalization.
+3. Confirm that the validator reports the intended application, database,
+   kernel, and effective output name.
+4. Confirm that dependency resolution and compatibility checks complete without
+   an error.
+5. Confirm that the downloader reports successful acquisition and checksum
+   validation for the required media.
+6. Record the catalog commit, selected names, generated BOM name when
+   applicable, execution run, and software-library location.
+
+Media availability can change independently of this repository. Validate the
+actual acquisition before you schedule installation.
+
+## If it fails
+
+- For a missing definition, correct `BOM_directory`, spelling, capitalization,
+  and the directory/file stem.
+- For an incompatible dynamic selection, choose a database and kernel declared
+  by the application definition.
+- For an authentication or entitlement failure, verify the SAP account and use
+  the diagnostic routing documented by the selected execution model.
+- For an obsolete URL, checksum mismatch, or unavailable archive, open an issue
+  in
+  [`Azure/SAP-automation-samples`](https://github.com/Azure/SAP-automation-samples/issues).
+  Include the definition path, repository commit, archive name, observed error,
+  and verifiable SAP replacement details when available.
+- For a validator or downloader implementation defect, open an issue in
+  [`Azure/sap-automation`](https://github.com/Azure/sap-automation/issues).
+- For a workflow or pipeline input defect, report it to the repository that
+  owns that execution model.
+
+An issue report does not guarantee that obsolete SAP media remains available
+or that a replacement is compatible. Do not bypass checksum or compatibility
+failures.
+
+## Next step
+
+Continue with the software-installation stage for your selected execution
+model. Use the validated BOM name and the acquired media location.


### PR DESCRIPTION
## Summary

- replace the minimal landing page with task-based sample navigation
- document Terraform workspace samples and SAP/BOM selection
- clarify `BOM_directory`, catalog ownership, and execution-model boundaries
- add contribution guidance while preserving `SUPPORT.md`

## Validation

- verified relative links and anchors
- checked catalog naming paths and source-backed BOM behavior
- reviewed documentation-only scope
- ran `git diff --check`