### PR TITLE
Fix SAPCAR installation path for S/4HANA 2025

### DIFF
--- a/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
+++ b/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
@@ -61,7 +61,7 @@ materials:
       filename:                         SAPCAR
       override_target_filename:         SAPCAR.EXE
       url:                              https://softwaredownloads.sap.com/file/0020000001143902023
-      path:                             downloads
+      path:                             download_basket
       permissions:                      '0755'
       download:                         True
       checksum:                         7f6f7efebcdb31bfde8ee1393f095473e1a1c71f138cc7f1f2a1dd561c3c61d2

--- a/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
+++ b/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
@@ -58,9 +58,11 @@ materials:
     # SAPCAR
     - name:                             "SAPCAR"
       archive:                          SAPCAR_1200-70007716.EXE
+      filename:                         SAPCAR
       override_target_filename:         SAPCAR.EXE
       url:                              https://softwaredownloads.sap.com/file/0020000001143902023
-      path:                             download_basket
+      path:                             downloads
+      permissions:                      '0755'
       download:                         True
       checksum:                         7f6f7efebcdb31bfde8ee1393f095473e1a1c71f138cc7f1f2a1dd561c3c61d2
 


### PR DESCRIPTION
## Summary
- download the SAPCAR archive into the installation role's expected downloads directory
- materialize it as SAPCAR with executable permissions
- retain the archive and software-download override metadata

## Failure addressed
The OS configuration workflow downloaded SAPCAR_1200-70007716.EXE into download_basket, then failed extracting SWPM because /usr/sap/install/downloads/SAPCAR did not exist.