### PR TITLE
fix: place S/4HANA 2025 SAPCAR in downloads

### DIFF
--- a/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
+++ b/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
@@ -61,7 +61,7 @@ materials:
       filename:                         SAPCAR
       override_target_filename:         SAPCAR.EXE
       url:                              https://softwaredownloads.sap.com/file/0020000001143902023
-      path:                             download_basket
+      path:                             downloads
       permissions:                      '0755'
       download:                         True
       checksum:                         7f6f7efebcdb31bfde8ee1393f095473e1a1c71f138cc7f1f2a1dd561c3c61d2


### PR DESCRIPTION
## Summary
- place the S/4HANA 2025 SAPCAR executable in the `downloads` directory
- align the BOM destination with the installer command `/usr/sap/install/downloads/SAPCAR`
- retain the executable filename and `0755` permissions added previously

## Validation
- parsed `SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml` with PyYAML
- ran `git diff --check`

## Operational note
Existing consolidated BOMs in SAP Library storage must be refreshed before deployments consume this updated path.