### PR TITLE
Fix S/4HANA 2025 HANA BOM dependency name

### DIFF
--- a/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
+++ b/SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml
@@ -30,7 +30,7 @@ patch_information:
 
 materials:
   dependencies:
-    - name:                             "HANA_2_00_SPS08_latest"
+    - name:                             "DB_HANA_2_00_SPS08_latest"
     - name:                             "SWPM20SP24_latest"
     - name:                             "SUM20SP26_latest"
   media:


### PR DESCRIPTION
## Summary
- align the S/4HANA 2025 HANA dependency with the DB_HANA_2_00_SPS08_latest BOM directory
- allow the software-download workflow to resolve and download the HANA database media

## Validation
- parsed SAP/S4_2025_SPS08ms/S4_2025_SPS08ms.yaml successfully