### PR TITLE
Fix HANA SPS08 VCH AFL compatibility

### DIFF
--- a/BOM/DB_HANA_2_00_SPS08_latest/DB_HANA_2_00_SPS08_latest.yaml
+++ b/BOM/DB_HANA_2_00_SPS08_latest/DB_HANA_2_00_SPS08_latest.yaml
@@ -57,10 +57,10 @@ materials:
       extractDir:                            CD_HDBSERVER/COMPONENTS
       creates:                               COMPONENTS/SAP_HANA_LCAPPS/packages
 
-    - name:                                  "VCH AFL 2023 Rev 89.0 only for HANA 2.0 Rev 89"
-      archive:                               VCH202300_2089_0-70007416.SAR
-      checksum:                              a9838de9edfbe0cd4b21efd18cdbfd49fef5e5547a0fd5664569d56ed3321ae2
-      url:                                   https://softwaredownloads.sap.com/file/0020000000008572026
+    - name:                                  "VCH AFL 2023 Rev 89.300 only for HANA 2.0 Rev 89.03"
+      archive:                               VCH202300_2089P_300-70007416.SAR
+      checksum:                              c8f9cfd070a3d74bc983ddcb6361391723f25e0cff2d886ba5ae7813a3cde4d0
+      url:                                   https://softwaredownloads.sap.com/file/0020000000396722026
       extract:                               True
       extractDir:                            CD_HDBSERVER/COMPONENTS
       creates:                               COMPONENTS/VCH_AFL_2023/packages


### PR DESCRIPTION
## Summary
Updates the HANA SPS08 VCH AFL 2023 media from the base 89.0 package to the SAP-verified 89.300 package required by HANA 2.00.089.03.

## Evidence
SAP Software Center Content Info confirms VCH202300_2089P_300-70007416.SAR, SAP file ID 0020000000396722026, and SHA-256 c8f9cfd070a3d74bc983ddcb6361391723f25e0cff2d886ba5ae7813a3cde4d0.

## Validation
YAML parsing and git diff --check passed.